### PR TITLE
Enhancement to move uploaded videos to same folder as within AEM

### DIFF
--- a/current/core/src/main/java/com/coresecure/brightcove/wrapper/utils/Constants.java
+++ b/current/core/src/main/java/com/coresecure/brightcove/wrapper/utils/Constants.java
@@ -12,6 +12,7 @@ public class Constants {
     public static final String EMPTY_URLPARAMS = "";
     public static final String EMPTY_Q_PARAM = "";
     public static final String EMPTY_SORT_PARAM = "";
+    public static final String DELIMITER_SLASH = "/";
 
     public static final String AUTHENTICATION_HEADER = "Authorization";
     public static final String ACCOUNTS_API_PATH = "/accounts/";


### PR DESCRIPTION
The current behavior when any video from AEM within a sub-folder is pushed to Brightcove is that it is always pushed to the root folder and there is a need to manually move it to the appropriate folder using Brightcove Admin page in AEM. This change will automatically move the video to correct folder same as in AEM.