### PR TITLE
Bgs-1562: refresh player ID list when account is changed in AEM Granite UI

### DIFF
--- a/current/all/pom.xml
+++ b/current/all/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.0.0</version>
+        <version>7.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/analyse/pom.xml
+++ b/current/analyse/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.0.0</version>
+        <version>7.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/core/pom.xml
+++ b/current/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.0.0</version>
+        <version>7.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>brightcove.core</artifactId>

--- a/current/it.tests/pom.xml
+++ b/current/it.tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.0.0</version>
+        <version>7.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/pom.xml
+++ b/current/pom.xml
@@ -21,7 +21,7 @@
     <groupId>com.coresecure</groupId>
     <artifactId>brightcove</artifactId>
     <packaging>pom</packaging>
-    <version>7.0.0</version>
+    <version>7.0.1</version>
     <description>Brightcove Connector</description>
 
     <modules>

--- a/current/ui.apps.structure/pom.xml
+++ b/current/ui.apps.structure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.0.0</version>
+        <version>7.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.apps/pom.xml
+++ b/current/ui.apps/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.0.0</version>
+        <version>7.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/page/brightcoveplayer/clientlib/listener.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/page/brightcoveplayer/clientlib/listener.js
@@ -41,33 +41,34 @@ document.addEventListener("DOMContentLoaded", function() {
 
 	async function fillPlayers(selectedAccount, selectedPlayer, savedValue) {
 		try {
+			// Clear existing options & value first
+			selectedPlayer.value = "";
+			const existing = selectedPlayer.querySelectorAll("coral-select-item");
+			existing.forEach(item => item.remove());
 
-			const response = await fetch("/bin/brightcove/api?a=players&account_id=" + selectedAccount);
+			// add a placeholder when list/selection is refreshed
+			const placeholder = new Coral.Select.Item();
+			placeholder.value = "";
+			placeholder.textContent = "Select";
+			selectedPlayer.appendChild(placeholder);
+
+			const response = await fetch("/bin/brightcove/api?a=players&account_id=" + encodeURIComponent(selectedAccount));
 			if (!response.ok) throw new Error(`HTTP error! Status: ${response.status}`);
 
 			const options = await response.json();
-
-			const responseData = (typeof options === 'string' ? JSON.parse(options) : options);
-
-			var playersList = [];
-			var allPlayerOptions = playerID.getElementsByTagName('coral-select-item');
-
-			for (var i = 0; i < allPlayerOptions.length; i++) {
-				playersList[i] = allPlayerOptions[i].value;
-			}
+			const responseData = (typeof options === "string" ? JSON.parse(options) : options);
 
 			for (const key in responseData) {
-				if (responseData.hasOwnProperty(key)) {
+				if (Object.prototype.hasOwnProperty.call(responseData, key)) {
 					for (const item in responseData[key]) {
-						if ($.inArray(responseData[key][item].id, playersList) == -1) {
-							let optionElement = new Coral.Select.Item();
-							optionElement.value = responseData[key][item].id;
-							optionElement.textContent = responseData[key][item].name;
-							selectedPlayer.appendChild(optionElement);
-						}
+						const opt = new Coral.Select.Item();
+						opt.value = responseData[key][item].id;
+						opt.textContent = responseData[key][item].name;
+						selectedPlayer.appendChild(opt);
 					}
 				}
 			}
+
 			if (savedValue) {
 				selectedPlayer.value = savedValue;
 			}

--- a/current/ui.config/pom.xml
+++ b/current/ui.config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.0.0</version>
+        <version>7.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.content/pom.xml
+++ b/current/ui.content/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.0.0</version>
+        <version>7.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.tests/pom.xml
+++ b/current/ui.tests/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.0.0</version>
+        <version>7.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
@BrianFranklin I have created a new branch called "cloud-master" to match the releases/7.0.0-cloud branch that I made the most recent builds from. My idea is that instead of having separate branches for each release, we will have a cloud-master and onPrem-master (or similar) and then dev versions of each. We can then make releases from each with the updated version and commit. Let me know if this works for you or if you'd prefer a different approach.

I've also checked and confirmed that your patch at https://github.com/brightcove/Adobe-AEM-Brightcove-Connector/commit/04a2e70ea69c21c5f7a23b28bfa67229f78d2d2c does not apply to cloud, so it is not included here, but I will make sure it is included when I need to make the next onPrem release.

As for the actual fix. here, the details are in the first commit message.