### PR TITLE
bgs-1562: update brightcove video player component

### DIFF
--- a/current/all/pom.xml
+++ b/current/all/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.0.1</version>
+        <version>7.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/analyse/pom.xml
+++ b/current/analyse/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.0.1</version>
+        <version>7.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/core/pom.xml
+++ b/current/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.0.1</version>
+        <version>7.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>brightcove.core</artifactId>

--- a/current/it.tests/pom.xml
+++ b/current/it.tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.0.1</version>
+        <version>7.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/pom.xml
+++ b/current/pom.xml
@@ -21,7 +21,7 @@
     <groupId>com.coresecure</groupId>
     <artifactId>brightcove</artifactId>
     <packaging>pom</packaging>
-    <version>7.0.1</version>
+    <version>7.0.2</version>
     <description>Brightcove Connector</description>
 
     <modules>

--- a/current/ui.apps.structure/pom.xml
+++ b/current/ui.apps.structure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.0.1</version>
+        <version>7.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.apps/pom.xml
+++ b/current/ui.apps/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.0.1</version>
+        <version>7.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-dialogs/js/dynamic_dropdown.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-dialogs/js/dynamic_dropdown.js
@@ -9,6 +9,54 @@
     const DIALOG_PLAYER_FIELD_SELECTOR = '.brightcove-dialog-player-dropdown';
     const DIALOG_ACCOUNT_FIELD_SELECTOR = '.brightcove-dialog-account-dropdown';
 
+    function setFoundationValue($el, value) {
+        var field = $el.adaptTo("foundation-field");
+        if (field) {
+            field.setValue(value);
+            return true;
+        }
+        return false;
+    }
+
+    function clearVideoAndPlayerSelections(contentSelector, playerSelector) {
+        // Clear stored selections so that later "selected=true" logic doesn't re-select old values
+        existingValues.videoPlayer = null;
+        existingValues.videoPlayerPL = null;
+        existingValues.playerPath = null;
+
+        // Clear UI values
+        // Player (coral select)
+        try {
+            playerSelector.value = "";
+        } catch (e) {}
+        setFoundationValue($(DIALOG_PLAYER_FIELD_SELECTOR), "");
+
+        // Video: autocomplete OR playlist select (depending on component)
+        if ($(DIALOG_PLAYLIST_FIELD_SELECTOR).length > 0) {
+            // playlist component: contentSelector is a coral select
+            try {
+                contentSelector.value = "";
+            } catch (e) {}
+            setFoundationValue($(DIALOG_PLAYLIST_FIELD_SELECTOR), "");
+        } else {
+            // player component: granite autocomplete
+            setFoundationValue($(DIALOG_VIDEO_FIELD_SELECTOR), "");
+
+            // clear the visible text input if foundation-field doesn’t
+            $(DIALOG_VIDEO_FIELD_SELECTOR)
+                .find("input[type='text'], input.coral-InputGroup-input")
+                .val("")
+                .trigger("change");
+        }
+
+        // Force player list to reload for the new account:
+        try {
+            playerSelector.items.clear();
+        } catch (e) {}
+
+        // For playlist select, updateAutocompleteWithAcountId() already does items.clear() so no need to repeat here
+    }
+
     function isBrightcoveDialog() {
         return ( $(DIALOG_ACCOUNT_FIELD_SELECTOR).length > 0 );
     }
@@ -115,6 +163,10 @@
             });
 
             accountSelector.addEventListener("change", function(event) {
+                // 1) Clear the dependent fields immediately so UI doesn’t show stale selection
+                clearVideoAndPlayerSelections(contentSelector, playerSelector);
+
+                // 2) Update video datasource URL / playlist items for the new account
                 updateAutocompleteWithAcountId();
             });
 

--- a/current/ui.config/pom.xml
+++ b/current/ui.config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.0.1</version>
+        <version>7.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.content/pom.xml
+++ b/current/ui.content/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.0.1</version>
+        <version>7.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.tests/pom.xml
+++ b/current/ui.tests/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.0.1</version>
+        <version>7.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
to clear selected values in the video/player dropdowns when the account value is changed.

Previously, the dropdowns themselves were getting updated if the user opened a dropdown after switching accounts, but the stale values from the previous account selections would continue to display in the video and player fields until new values were selected from the dropdowns.

Also update versions to 7.0.2