### PR TITLE
fix: guard against null original_filename in VideoImportCallable.clea…

### DIFF
--- a/current/core/src/main/java/com/coresecure/brightcove/wrapper/schedulers/asset_integrator/callables/VideoImportCallable.java
+++ b/current/core/src/main/java/com/coresecure/brightcove/wrapper/schedulers/asset_integrator/callables/VideoImportCallable.java
@@ -209,11 +209,13 @@ public class VideoImportCallable implements Callable<String> {
     }
 
     private Asset getAsset(String oldpath, String localpath ){
-        Resource resource = resourceResolver.getResource(oldpath);
-        if(resource != null) {
-            return resource.adaptTo(Asset.class);
+        if (oldpath != null) {
+            Resource resource = resourceResolver.getResource(oldpath);
+            if (resource != null) {
+                return resource.adaptTo(Asset.class);
+            }
         }
-        resource = resourceResolver.getResource(localpath);
+        Resource resource = resourceResolver.getResource(localpath);
         if(resource != null) {
             return resource.adaptTo(Asset.class);
         }

--- a/current/core/src/main/java/com/coresecure/brightcove/wrapper/schedulers/asset_integrator/callables/VideoImportCallable.java
+++ b/current/core/src/main/java/com/coresecure/brightcove/wrapper/schedulers/asset_integrator/callables/VideoImportCallable.java
@@ -261,7 +261,7 @@ public class VideoImportCallable implements Callable<String> {
 
             //USNIG THE CONFIGURATION - BUILD THE DIRECTORY TO SEARCH FOR THE LOCAL ASSETS OR BUILD INTO
             String localpath = cleanPath(confPath, brightcove_filename, brightcove_folder_id);
-            String oldpath = cleanPath(confPath, original_filename, brightcove_folder_id);
+            String oldpath = original_filename != null ? cleanPath(confPath, original_filename, brightcove_folder_id) : null;
 
             LOGGER.trace("SEARCHING FOR LOCAL ASSET");
             LOGGER.trace(">>ORIGINAL: " + oldpath);


### PR DESCRIPTION
…nPath

Videos without an original_filename field caused a NullPointerException in String.concat() when building oldpath. Skip cleanPath when original_filename is null since there is no old path to look up.