### PR TITLE
fix: restore publish-to-Brightcove sync on local and AEMaaCS (7.1.3)

### DIFF
--- a/current/all/pom.xml
+++ b/current/all/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.2</version>
+        <version>7.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/analyse/pom.xml
+++ b/current/analyse/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.2</version>
+        <version>7.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/core/pom.xml
+++ b/current/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.2</version>
+        <version>7.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>brightcove.core</artifactId>

--- a/current/core/src/main/java/com/coresecure/brightcove/wrapper/filter/CustomAddDialogTabFilter.java
+++ b/current/core/src/main/java/com/coresecure/brightcove/wrapper/filter/CustomAddDialogTabFilter.java
@@ -46,6 +46,7 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
 import org.apache.sling.api.wrappers.SlingHttpServletResponseWrapper;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.slf4j.Logger;
@@ -160,7 +161,13 @@ public class CustomAddDialogTabFilter extends SlingSafeMethodsServlet implements
     }
 
     private ObjectNode getOriginalTabs(String componentPath, ObjectNode originalDialog, final SlingHttpServletRequest slingRequest) throws IOException, RepositoryException{
-        ObjectNode originalTabs = (ObjectNode) ((ObjectNode) originalDialog.get("items")).get("tabs").get("items");
+        JsonNode itemsNode = originalDialog.get("items");
+        if (itemsNode == null || !itemsNode.isObject()) throw new IOException("Dialog JSON missing 'items' node");
+        JsonNode tabsNode = itemsNode.get("tabs");
+        if (tabsNode == null || !tabsNode.isObject()) throw new IOException("Dialog JSON missing 'items/tabs' node");
+        JsonNode tabItemsNode = tabsNode.get("items");
+        if (tabItemsNode == null || !tabItemsNode.isObject()) throw new IOException("Dialog JSON missing 'items/tabs/items' node");
+        ObjectNode originalTabs = (ObjectNode) tabItemsNode;
         Resource componentRes = slingRequest.getResourceResolver().getResource(componentPath);
         if (componentRes != null) {
             for (Resource item : getInheritResources(componentRes))

--- a/current/core/src/main/java/com/coresecure/brightcove/wrapper/listeners/BrightcovePublishListener.java
+++ b/current/core/src/main/java/com/coresecure/brightcove/wrapper/listeners/BrightcovePublishListener.java
@@ -1,6 +1,7 @@
 package com.coresecure.brightcove.wrapper.listeners;
 
 import com.day.cq.replication.ReplicationAction;
+import com.day.cq.replication.ReplicationActionType;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -42,7 +43,8 @@ import java.util.Date;
 
 @Component(service = EventHandler.class, immediate = true, property = {
         "service.description" + "=Brightcove Distribution Event Listener ",
-        EventConstants.EVENT_TOPIC + "= org/apache/sling/distribution/agent/package/distributed"
+        EventConstants.EVENT_TOPIC + "=org/apache/sling/distribution/agent/package/distributed",
+        EventConstants.EVENT_TOPIC + "=" + ReplicationAction.EVENT_TOPIC
 })
 @Designate(ocd = BrightcovePublishListener.EventListenerPageActivationListenerConfiguration.class)
 public class BrightcovePublishListener implements EventHandler {
@@ -162,33 +164,35 @@ public class BrightcovePublishListener implements EventHandler {
         Resource assetRes = _asset.adaptTo(Resource.class);
 
         if (assetRes == null) {
+            LOG.warn("activateAsset: could not adapt asset to Resource, skipping: {}", _asset.getPath());
             return;
         }
 
         Resource metadataRes = assetRes.getChild(Constants.ASSET_METADATA_PATH);
         if (metadataRes == null) {
+            LOG.warn("activateAsset: metadata node not found at {}/{}, skipping", _asset.getPath(), Constants.ASSET_METADATA_PATH);
             return;
         }
 
         ModifiableValueMap brc_lastsync_map = metadataRes.adaptTo(ModifiableValueMap.class);
         if (brc_lastsync_map == null) {
+            LOG.warn("activateAsset: could not obtain ModifiableValueMap for {}, skipping (check brightcove_admin write permissions)", _asset.getPath());
             return;
         }
 
-        Long jcr_lastmod = _asset.getLastModified();
         Long brc_lastsync_time = brc_lastsync_map.get(Constants.BRC_LASTSYNC, Long.class);
 
         brc_lastsync_map.put(Constants.BRC_STATE, "ACTIVE");
 
         if (brc_lastsync_time == null) {
 
-            // we need to activate a new asset here
+            // no prior sync — upload as new asset
             LOG.info("Activating New Brightcove Asset: {}", _asset.getPath());
             activateNew(_asset, serviceUtil, video, brc_lastsync_map);
 
-        } else if (jcr_lastmod > brc_lastsync_time) {
+        } else {
 
-            // we need to modify an existing asset here
+            // asset was previously synced — update it
             LOG.info("Activating Modified Brightcove Asset: {}", _asset.getPath());
             activateModified(_asset, serviceUtil, video, brc_lastsync_map);
 
@@ -248,7 +252,7 @@ public class BrightcovePublishListener implements EventHandler {
 
     @Override
     public void handleEvent(Event event) {
-        LOG.error("********************* Event info:" + event.toString());
+        LOG.debug("handleEvent: topic={}", event.getTopic());
         // check that the service is enabled and that we are running on Author
         if (enabled && slingSettings.getRunModes().contains("author")) {
 
@@ -260,64 +264,97 @@ public class BrightcovePublishListener implements EventHandler {
                         (Object) SERVICE_ACCOUNT_IDENTIFIER);
 
                 // Get the Service resource resolver
-                ResourceResolver rr = resourceResolverFactory.getServiceResourceResolver(authInfo);
+                try (ResourceResolver rr = resourceResolverFactory.getServiceResourceResolver(authInfo)) {
 
-                // grab all the configured services
-                ConfigurationGrabber cg = ServiceUtil.getConfigurationGrabber();
-                Set<String> services = cg.getAvailableServices();
+                    // grab all the configured services
+                    ConfigurationGrabber cg = ServiceUtil.getConfigurationGrabber();
+                    Set<String> services = cg.getAvailableServices();
 
-                // set up a variable to store the paths
-                paths = new LinkedHashMap<>();
+                    // set up a variable to store the paths
+                    paths = new LinkedHashMap<>();
 
-                // for each service, check to see the integration path
-                for (String service : services) {
+                    // for each service, check to see the integration path
+                    for (String service : services) {
 
-                    // get the service from that account ID
-                    ConfigurationService brcService = cg.getConfigurationService(service);
+                        // get the service from that account ID
+                        ConfigurationService brcService = cg.getConfigurationService(service);
 
-                    // add the account ID to a HashMap with a key of the path
-                    paths.put(brcService.getAssetIntegrationPath(), brcService.getAccountID());
+                        // add the account ID to a HashMap with a key of the path
+                        paths.put(brcService.getAssetIntegrationPath(), brcService.getAccountID());
 
-                }
+                    }
 
-                String[] activatedAssets = (String[]) event.getProperty("paths");
+                    // extract paths and action type depending on which event system fired
+                    String[] activatedAssets;
+                    boolean isActivate;
+                    boolean isDeactivate;
+                    if (ReplicationAction.EVENT_TOPIC.equals(event.getTopic())) {
+                        activatedAssets = (String[]) event.getProperty("paths");
+                        ReplicationAction replicationAction = ReplicationAction.fromEvent(event);
+                        if (replicationAction == null) {
+                            return;
+                        }
+                        ReplicationActionType replicationActionType = replicationAction.getType();
+                        isActivate = ReplicationActionType.ACTIVATE.equals(replicationActionType);
+                        isDeactivate = ReplicationActionType.DEACTIVATE.equals(replicationActionType);
+                    } else {
+                        activatedAssets = (String[]) event.getProperty("distribution.paths");
+                        isActivate = "ADD".equals(event.getProperty("distribution.type"));
+                        isDeactivate = "DELETE".equals(event.getProperty("distribution.type"));
+                    }
 
-                // iterate through all assets that were part of this replication event
-                for (String asset : activatedAssets) {
+                    if (activatedAssets == null) {
+                        return;
+                    }
 
-                    // get all the account IDs of the integration paths
-                    Set<String> keys = paths.keySet();
+                    // iterate through all assets that were part of this replication event
+                    for (String asset : activatedAssets) {
 
-                    // check against the paths for each ConfigurationService
-                    for (String key : keys) {
+                        // get all the account IDs of the integration paths
+                        Set<String> keys = paths.keySet();
 
-                        // check if this asset lives underneath a Brightcove managed folder
-                        if (asset.contains(key)) {
+                        // check against the paths for each ConfigurationService
+                        for (String key : keys) {
 
-                            // get the account ID
-                            String brightcoveAccountId = paths.get(key);
-                            LOG.info("Found Brightcove Account ID #{} for {}", brightcoveAccountId, asset);
+                            // check if this asset lives underneath a Brightcove managed folder
+                            if (asset.contains(key)) {
 
-                            // get a proper Asset object from the path
-                            Resource assetResource = rr.getResource(asset);
-                            Asset _asset = assetResource.adaptTo(Asset.class);
+                                // get the account ID
+                                String brightcoveAccountId = paths.get(key);
+                                LOG.info("Found Brightcove Account ID #{} for {}", brightcoveAccountId, asset);
 
-                            // check the activation type
-                            if ("ACTIVATE".equals(event.getProperty("type"))) {
+                                // get a proper Asset object from the path
+                                Resource assetResource = rr.getResource(asset);
+                                if (assetResource == null) {
+                                    LOG.warn("handleEvent: resource not found for path {}, skipping", asset);
+                                    continue;
+                                }
+                                Asset _asset = assetResource.adaptTo(Asset.class);
+                                if (_asset == null) {
+                                    LOG.warn("handleEvent: could not adapt resource to Asset at {}, skipping", asset);
+                                    continue;
+                                }
 
-                                // upload or modify the asset
-                                activateAsset(rr, _asset, brightcoveAccountId);
+                                // check the activation type
+                                if (isActivate) {
 
-                            } else if ("DEACTIVATE".equals(event.getProperty("type"))) {
+                                    // upload or modify the asset
+                                    activateAsset(rr, _asset, brightcoveAccountId);
 
-                                // delete the asset
-                                deactivateAsset(rr, _asset, brightcoveAccountId);
+                                } else if (isDeactivate) {
+
+                                    // delete the asset
+                                    deactivateAsset(rr, _asset, brightcoveAccountId);
+
+                                }
 
                             }
 
                         }
 
                     }
+
+                    rr.commit();
 
                 }
 

--- a/current/core/src/main/java/com/coresecure/brightcove/wrapper/schedulers/asset_integrator/callables/VideoImportCallable.java
+++ b/current/core/src/main/java/com/coresecure/brightcove/wrapper/schedulers/asset_integrator/callables/VideoImportCallable.java
@@ -288,7 +288,7 @@ public class VideoImportCallable implements Callable<String> {
                 return  Thread.currentThread().getName();
             }
 
-            String name = innerObj.get(Constants.NAME).asText();
+            String name = innerObj.has(Constants.NAME) && !innerObj.get(Constants.NAME).isNull() ? innerObj.get(Constants.NAME).asText() : "";
             String brightcove_filename = id + ".mp4"; //BRIGHTCOVE FILE NAME IS ID + . MP4 <-
             String original_filename = cleanFilename(innerObj);
             String brightcove_folder_id = (!innerObj.has(Constants.FOLDER_ID) || innerObj.get(Constants.FOLDER_ID).isNull() ? "" : innerObj.get(Constants.FOLDER_ID).asText());
@@ -322,19 +322,24 @@ public class VideoImportCallable implements Callable<String> {
                 Date local_mod_date = new Date(newAsset.getLastModified());
 
                 SimpleDateFormat sdf = new SimpleDateFormat(ISO_8601_24H_FULL_FORMAT);
-                Date remote_date = sdf.parse(innerObj.get(Constants.UPDATED_AT).asText());
-
-                //LOCAL COMPARISON DATE TO SEE IF IT NEEDS TO UPDATE
-                if (local_mod_date.compareTo(remote_date) < 0) {
-                    LOGGER.trace("OLDERS-DATE>>>>>" + local_mod_date);
-                    LOGGER.trace("PARSED-DATE>>>>>" + remote_date);
-                    LOGGER.trace(local_mod_date + " < " + remote_date);
-                    LOGGER.trace("MODIFICATION DETECTED");
+                if (!innerObj.has(Constants.UPDATED_AT) || innerObj.get(Constants.UPDATED_AT).isNull()) {
+                    LOGGER.warn("Asset {} has no {} — forcing update", localpath, Constants.UPDATED_AT);
                     serviceUtil.updateAsset(newAsset, innerObj, resourceResolver, requestedServiceAccount);
-
                 } else {
-                    LOGGER.trace("No Changes to be Made = Asset is equivalent");
+                    Date remote_date = sdf.parse(innerObj.get(Constants.UPDATED_AT).asText());
 
+                    //LOCAL COMPARISON DATE TO SEE IF IT NEEDS TO UPDATE
+                    if (local_mod_date.compareTo(remote_date) < 0) {
+                        LOGGER.trace("OLDERS-DATE>>>>>" + local_mod_date);
+                        LOGGER.trace("PARSED-DATE>>>>>" + remote_date);
+                        LOGGER.trace(local_mod_date + " < " + remote_date);
+                        LOGGER.trace("MODIFICATION DETECTED");
+                        serviceUtil.updateAsset(newAsset, innerObj, resourceResolver, requestedServiceAccount);
+
+                    } else {
+                        LOGGER.trace("No Changes to be Made = Asset is equivalent");
+
+                    }
                 }
 
             }

--- a/current/it.tests/pom.xml
+++ b/current/it.tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.2</version>
+        <version>7.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/pom.xml
+++ b/current/pom.xml
@@ -21,7 +21,7 @@
     <groupId>com.coresecure</groupId>
     <artifactId>brightcove</artifactId>
     <packaging>pom</packaging>
-    <version>7.1.2</version>
+    <version>7.1.3</version>
     <description>Brightcove Connector</description>
 
     <modules>

--- a/current/ui.apps.structure/pom.xml
+++ b/current/ui.apps.structure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.2</version>
+        <version>7.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.apps/pom.xml
+++ b/current/ui.apps/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.2</version>
+        <version>7.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.config/pom.xml
+++ b/current/ui.config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.2</version>
+        <version>7.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.content/pom.xml
+++ b/current/ui.content/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.2</version>
+        <version>7.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.tests/pom.xml
+++ b/current/ui.tests/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.2</version>
+        <version>7.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
## Summary

- **Publish listener not firing**: A leading space in the Sling Distribution event topic registration silently prevented `BrightcovePublishListener` from receiving events. Fixed topic string and registered both `org/apache/sling/distribution/agent/package/distributed` (AEMaaCS) and `ReplicationAction.EVENT_TOPIC` (local AEM SDK) so sync works in both environments.
- **Event property names corrected**: Sling Distribution events use `distribution.paths` / `distribution.type` (ADD/DELETE), not the CQ Replication property names. Handler now branches on topic to read the correct properties.
- **Timestamp gate removed**: The `jcr_lastmod > brc_lastsync` guard in `activateAsset()` could never pass after the first sync — `brc_lastsync` is always set to now at sync time. Removed the gate so an explicit publish always triggers a sync.
- **ResourceResolver leak fixed**: `handleEvent()` now uses try-with-resources to ensure the resolver is always closed.
- **Null safety**: Added null checks for `assetResource` and `_asset` in `handleEvent()`, guarded chained `get()` calls in `CustomAddDialogTabFilter`, and guarded `NAME` / `UPDATED_AT` access in `VideoImportCallable` against missing Jackson nodes (regression from BCON-90 Jackson migration where `JSONException` was silently replaced by NPE).
- **Debug log removed**: Removed `LOG.error("***...")` banner left in from debugging.
- **Version bumped to 7.1.3.**

## Test plan

- [ ] Publish a video asset to Brightcove from local AEM SDK — confirm it uploads/updates
- [ ] Publish a video asset from AEMaaCS — confirm it uploads/updates
- [ ] Unpublish an asset — confirm it is marked INACTIVE in Brightcove
- [ ] Publish an asset that has already been synced — confirm it updates (not skipped)
- [ ] Confirm no error-level log spam on publish events

🤖 Generated with [Claude Code](https://claude.com/claude-code)