### PR TITLE
feat(BCON-128/129/130/131/152): UI/UX fixes and language variant CRUD

### DIFF
--- a/current/core/src/main/java/com/coresecure/brightcove/wrapper/api/CmsAPI.java
+++ b/current/core/src/main/java/com/coresecure/brightcove/wrapper/api/CmsAPI.java
@@ -811,6 +811,7 @@ public class CmsAPI {
         if (authToken != null) {
             Map<String, String> headers = new HashMap<String, String>();
             headers.put(Constants.AUTHENTICATION_HEADER, authToken.getTokenType() + " " + authToken.getToken());
+            headers.put(Constants.CONTENT_TYPE_HEADER, "application/json");
             String targetURL = Constants.ACCOUNTS_API_PATH + account.getAccount_ID() + Constants.VIDEOS_API_PATH + videoId + "/variants";
             try {
                 String response = account.platform.postAPI(targetURL, variantBody.toPrettyString(), headers);

--- a/current/core/src/main/java/com/coresecure/brightcove/wrapper/api/CmsAPI.java
+++ b/current/core/src/main/java/com/coresecure/brightcove/wrapper/api/CmsAPI.java
@@ -841,6 +841,24 @@ public class CmsAPI {
         return json;
     }
 
+    // DELETE /accounts/{accountId}/videos/{videoId}/variants/{language}
+    public ObjectNode deleteVariant(String videoId, String language) {
+        ObjectNode json = JsonNodeFactory.instance.objectNode();
+        TokenObj authToken = account.getLoginToken();
+        if (authToken != null) {
+            Map<String, String> headers = new HashMap<String, String>();
+            headers.put(Constants.AUTHENTICATION_HEADER, authToken.getTokenType() + " " + authToken.getToken());
+            String targetURL = Constants.ACCOUNTS_API_PATH + account.getAccount_ID() + Constants.VIDEOS_API_PATH + videoId + "/variants/" + language;
+            try {
+                String response = account.platform.deleteAPI(targetURL, headers);
+                if (response != null && !response.isEmpty()) json = JsonReader.readJsonFromString(response);
+            } catch (IOException e) {
+                LOGGER.error(e.getClass().getName(), e);
+            }
+        }
+        return json;
+    }
+
     public ArrayNode getExperiencesJSONArrayResponse(String targetURL, String urlParameters, Map<String, String> headers) {
         ArrayNode json = JsonNodeFactory.instance.arrayNode();
         try

--- a/current/core/src/main/java/com/coresecure/brightcove/wrapper/api/CmsAPI.java
+++ b/current/core/src/main/java/com/coresecure/brightcove/wrapper/api/CmsAPI.java
@@ -804,6 +804,42 @@ public class CmsAPI {
 
     }
 
+    // POST /accounts/{accountId}/videos/{videoId}/variants
+    public ObjectNode addVariant(String videoId, ObjectNode variantBody) {
+        ObjectNode json = JsonNodeFactory.instance.objectNode();
+        TokenObj authToken = account.getLoginToken();
+        if (authToken != null) {
+            Map<String, String> headers = new HashMap<String, String>();
+            headers.put(Constants.AUTHENTICATION_HEADER, authToken.getTokenType() + " " + authToken.getToken());
+            String targetURL = Constants.ACCOUNTS_API_PATH + account.getAccount_ID() + Constants.VIDEOS_API_PATH + videoId + "/variants";
+            try {
+                String response = account.platform.postAPI(targetURL, variantBody.toPrettyString(), headers);
+                if (response != null && !response.isEmpty()) json = JsonReader.readJsonFromString(response);
+            } catch (IOException e) {
+                LOGGER.error(e.getClass().getName(), e);
+            }
+        }
+        return json;
+    }
+
+    // PATCH /accounts/{accountId}/videos/{videoId}/variants/{language}
+    public ObjectNode updateVariant(String videoId, String language, ObjectNode variantBody) {
+        ObjectNode json = JsonNodeFactory.instance.objectNode();
+        TokenObj authToken = account.getLoginToken();
+        if (authToken != null) {
+            Map<String, String> headers = new HashMap<String, String>();
+            headers.put(Constants.AUTHENTICATION_HEADER, authToken.getTokenType() + " " + authToken.getToken());
+            String targetURL = Constants.ACCOUNTS_API_PATH + account.getAccount_ID() + Constants.VIDEOS_API_PATH + videoId + "/variants/" + language;
+            try {
+                String response = account.platform.patchAPI(targetURL, variantBody.toPrettyString(), headers);
+                if (response != null && !response.isEmpty()) json = JsonReader.readJsonFromString(response);
+            } catch (IOException e) {
+                LOGGER.error(e.getClass().getName(), e);
+            }
+        }
+        return json;
+    }
+
     public ArrayNode getExperiencesJSONArrayResponse(String targetURL, String urlParameters, Map<String, String> headers) {
         ArrayNode json = JsonNodeFactory.instance.arrayNode();
         try

--- a/current/core/src/main/java/com/coresecure/brightcove/wrapper/sling/ServiceUtil.java
+++ b/current/core/src/main/java/com/coresecure/brightcove/wrapper/sling/ServiceUtil.java
@@ -809,7 +809,10 @@ public class ServiceUtil {
             } else {
                 LOGGER.trace("setMapJSONArray() is using a generic array for " + key);
                 List<String> vals = new ArrayList<>();
-                for (int cnt = 0; cnt < objArray.size(); cnt++) vals.add(objArray.get(cnt).asText());
+                for (int cnt = 0; cnt < objArray.size(); cnt++) {
+                    com.fasterxml.jackson.databind.JsonNode el = objArray.get(cnt);
+                    vals.add(el.isValueNode() ? el.asText() : el.toString());
+                }
                 map.put(key, vals.toArray(new String[0]));
             }
         }catch (Exception e) {

--- a/current/core/src/main/java/com/coresecure/brightcove/wrapper/webservices/BrcApi.java
+++ b/current/core/src/main/java/com/coresecure/brightcove/wrapper/webservices/BrcApi.java
@@ -729,8 +729,20 @@ public class BrcApi extends SlingAllMethodsServlet {
             result = addVariant(request);
         } else if ("update_variant".equals(requestedAPI)) {
             result = updateVariant(request);
+        } else if ("delete_variant".equals(requestedAPI)) {
+            result = deleteVariant(request);
         } else {
             result.put(Constants.ERROR, 404);
+        }
+        return result;
+    }
+
+    private ObjectNode deleteVariant(SlingHttpServletRequest request) throws IOException {
+        ObjectNode result = JsonNodeFactory.instance.objectNode();
+        String videoId  = request.getParameter("videoId");
+        String language = request.getParameter("language");
+        if (videoId != null && !videoId.isEmpty() && language != null && !language.isEmpty()) {
+            result = brAPI.cms.deleteVariant(videoId, language);
         }
         return result;
     }

--- a/current/core/src/main/java/com/coresecure/brightcove/wrapper/webservices/BrcApi.java
+++ b/current/core/src/main/java/com/coresecure/brightcove/wrapper/webservices/BrcApi.java
@@ -725,8 +725,65 @@ public class BrcApi extends SlingAllMethodsServlet {
             result = getLabels(request);
         } else if ("create_label".equals(requestedAPI)) {
             result = createLabel(request);
+        } else if ("add_variant".equals(requestedAPI)) {
+            result = addVariant(request);
+        } else if ("update_variant".equals(requestedAPI)) {
+            result = updateVariant(request);
         } else {
             result.put(Constants.ERROR, 404);
+        }
+        return result;
+    }
+
+    private ObjectNode addVariant(SlingHttpServletRequest request) throws IOException {
+        ObjectNode result = JsonNodeFactory.instance.objectNode();
+        String videoId = request.getParameter("videoId");
+        String language = request.getParameter("language");
+        if (videoId != null && !videoId.isEmpty() && language != null && !language.isEmpty()) {
+            ObjectNode variantBody = JsonNodeFactory.instance.objectNode();
+            variantBody.put("language", language);
+            String name = request.getParameter(Constants.NAME);
+            if (name != null) variantBody.put(Constants.NAME, name);
+            String description = request.getParameter(Constants.DESCRIPTION);
+            if (description != null) variantBody.put(Constants.DESCRIPTION, description);
+            String longDescription = request.getParameter(Constants.LONG_DESCRIPTION);
+            if (longDescription != null) variantBody.put(Constants.LONG_DESCRIPTION, longDescription);
+            String customFieldsJson = request.getParameter("custom_fields");
+            if (customFieldsJson != null && !customFieldsJson.isEmpty()) {
+                try {
+                    variantBody.set(Constants.CUSTOM_FIELDS, MAPPER.readTree(customFieldsJson));
+                } catch (Exception e) {
+                    variantBody.set(Constants.CUSTOM_FIELDS, JsonNodeFactory.instance.objectNode());
+                }
+            } else {
+                variantBody.set(Constants.CUSTOM_FIELDS, JsonNodeFactory.instance.objectNode());
+            }
+            result = brAPI.cms.addVariant(videoId, variantBody);
+        }
+        return result;
+    }
+
+    private ObjectNode updateVariant(SlingHttpServletRequest request) throws IOException {
+        ObjectNode result = JsonNodeFactory.instance.objectNode();
+        String videoId = request.getParameter("videoId");
+        String language = request.getParameter("language");
+        if (videoId != null && !videoId.isEmpty() && language != null && !language.isEmpty()) {
+            ObjectNode variantBody = JsonNodeFactory.instance.objectNode();
+            String name = request.getParameter(Constants.NAME);
+            if (name != null) variantBody.put(Constants.NAME, name);
+            String description = request.getParameter(Constants.DESCRIPTION);
+            if (description != null) variantBody.put(Constants.DESCRIPTION, description);
+            String longDescription = request.getParameter(Constants.LONG_DESCRIPTION);
+            if (longDescription != null) variantBody.put(Constants.LONG_DESCRIPTION, longDescription);
+            String customFieldsJson = request.getParameter("custom_fields");
+            if (customFieldsJson != null && !customFieldsJson.isEmpty()) {
+                try {
+                    variantBody.set(Constants.CUSTOM_FIELDS, MAPPER.readTree(customFieldsJson));
+                } catch (Exception e) {
+                    variantBody.set(Constants.CUSTOM_FIELDS, JsonNodeFactory.instance.objectNode());
+                }
+            }
+            result = brAPI.cms.updateVariant(videoId, language, variantBody);
         }
         return result;
     }

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-custom-assets-menu-options-visibility/css.txt
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-custom-assets-menu-options-visibility/css.txt
@@ -1,0 +1,2 @@
+#base=css
+asset-details-video-player.css

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-custom-assets-menu-options-visibility/css/asset-details-video-player.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-custom-assets-menu-options-visibility/css/asset-details-video-player.css
@@ -1,0 +1,19 @@
+/* BCON-130: Make the Video.js player fill the DAM asset details preview area.
+ * AEM initialises #dam_video with inline style="width:300px; height:0px" which
+ * causes the poster/video to render at ~160x90. !important is required to
+ * override those inline values. */
+
+#dam_video.video-js {
+    width: 100% !important;
+    height: auto !important;
+    aspect-ratio: 16 / 9;
+    max-height: 100%;
+}
+
+#dam_video .vjs-tech {
+    position: relative !important;
+    width: 100% !important;
+    height: 100% !important;
+    max-width: 100% !important;
+    max-height: 100% !important;
+}

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-custom-assets-menu-options-visibility/css/asset-details-video-player.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-custom-assets-menu-options-visibility/css/asset-details-video-player.css
@@ -1,7 +1,9 @@
 /* BCON-130: Make the Video.js player fill the DAM asset details preview area.
  * AEM initialises #dam_video with inline style="width:300px; height:0px" which
  * causes the poster/video to render at ~160x90. !important is required to
- * override those inline values. */
+ * override those inline values.
+ * Do NOT override .vjs-tech positioning — Video.js manages its own internal
+ * layout and changing it from absolute causes the poster to double-render. */
 
 #dam_video.video-js {
     width: 100% !important;
@@ -10,10 +12,9 @@
     max-height: 100%;
 }
 
-#dam_video .vjs-tech {
-    position: relative !important;
-    width: 100% !important;
-    height: 100% !important;
-    max-width: 100% !important;
-    max-height: 100% !important;
+/* Scale the poster to fill the player area without tiling */
+#dam_video .vjs-poster {
+    background-size: cover !important;
+    background-position: center center !important;
+    background-repeat: no-repeat !important;
 }

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-custom-assets-menu-options-visibility/js/custom-assets-menu-options-visibility.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-custom-assets-menu-options-visibility/js/custom-assets-menu-options-visibility.js
@@ -42,6 +42,25 @@
 
     getCurrentUserInfo();
 
+    // BCON-130: Swap the low-res brc_thumbnail.png for the full-size brc_poster.png
+    // on the DAM asset details page. AEM's Video.js component hardcodes the thumbnail
+    // rendition as the poster; we poll until Video.js has rendered .vjs-poster and
+    // then update its background-image URL.
+    if (location.pathname.indexOf('/assetdetails.html/') === 0) {
+        var posterSwapInterval = setInterval(function () {
+            var vjsPoster = document.querySelector('#dam_video .vjs-poster');
+            if (vjsPoster) {
+                clearInterval(posterSwapInterval);
+                var bg = vjsPoster.style.backgroundImage || window.getComputedStyle(vjsPoster).backgroundImage;
+                if (bg && bg.indexOf('brc_thumbnail.png') !== -1) {
+                    vjsPoster.style.backgroundImage = bg.replace('brc_thumbnail.png', 'brc_poster.png');
+                }
+            }
+        }, 200);
+        // Stop polling after 15 seconds regardless
+        setTimeout(function () { clearInterval(posterSwapInterval); }, 15000);
+    }
+
     function processActionMenuItems(tile) {
 
         if (tile) {

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -703,6 +703,31 @@ input#search {
   height: 30px;
 }
 
+#searchClear,
+#searchClear_pl {
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  color: #999;
+  padding: 0;
+  line-height: 1;
+}
+
+#searchClear:hover,
+#searchClear_pl:hover {
+  color: #333;
+}
+
+input#search,
+input#search_pl {
+  padding-right: 20px;
+}
+
 tr.select {
   background-color: #5F9CE3;
   color: #fff;

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcAdmin.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcAdmin.js
@@ -35,6 +35,10 @@
 var brc_admin = brc_admin || {},
     apiLocation = brc_admin.apiProxy; //This should be set to point to proxy.jsp on your server
 
+function togglePlSearchHint(field) {
+    var hint = document.getElementById('pl_search_hint');
+    if (hint) hint.style.display = (field === 'find_playlist_by_name') ? 'block' : 'none';
+}
 
 //Default Fields
 //specifying a subset of fields cuts down on the amount of data sent over the wire.  If you want to access another field, include it here.

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcAdmin.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcAdmin.js
@@ -107,7 +107,11 @@ function getFindPlaylistsURL() {
     paging.allPlaylists = (paging.currentFunction == getAllPlaylistsURL) ? paging.generic : paging.allPlaylists;
     paging.currentFunction = getAllPlaylistsURL;
     if (searchVal != "" && searchVal != "Search Playlists") {
-        if (searchField == "find_playlist_by_id") {
+        if (searchField == "find_playlist_by_name") {
+            return apiLocation +
+                '.js?account_id='+$("#selAccount").val()+'&a=search_playlists&callback=showAllPlaylistsCallBack&query=name:' + searchVal
+                + '&limit=' + paging.size + '&start=' + paging.allPlaylists
+        } else if (searchField == "find_playlist_by_id") {
             return apiLocation +
                 '.js?isID=true&account_id='+$("#selAccount").val()+'&a=search_playlists&callback=showAllPlaylistsCallBack&query=' + searchVal
                 + '&limit=' + paging.size + '&start=' + paging.allPlaylists

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcAdmin.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcAdmin.js
@@ -109,7 +109,7 @@ function getFindPlaylistsURL() {
     if (searchVal != "" && searchVal != "Search Playlists") {
         if (searchField == "find_playlist_by_name") {
             return apiLocation +
-                '.js?account_id='+$("#selAccount").val()+'&a=search_playlists&callback=showAllPlaylistsCallBack&query=' + encodeURIComponent('+name:' + searchVal)
+                '.js?account_id='+$("#selAccount").val()+'&a=search_playlists&callback=showAllPlaylistsCallBack&query=' + searchVal
                 + '&limit=' + paging.size + '&start=' + paging.allPlaylists
         } else if (searchField == "find_playlist_by_id") {
             return apiLocation +

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcAdmin.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcAdmin.js
@@ -109,7 +109,7 @@ function getFindPlaylistsURL() {
     if (searchVal != "" && searchVal != "Search Playlists") {
         if (searchField == "find_playlist_by_name") {
             return apiLocation +
-                '.js?account_id='+$("#selAccount").val()+'&a=search_playlists&callback=showAllPlaylistsCallBack&query=name:' + searchVal
+                '.js?account_id='+$("#selAccount").val()+'&a=search_playlists&callback=showAllPlaylistsCallBack&query=' + encodeURIComponent('+name:' + searchVal)
                 + '&limit=' + paging.size + '&start=' + paging.allPlaylists
         } else if (searchField == "find_playlist_by_id") {
             return apiLocation +

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -793,6 +793,7 @@ function buildPlaylistList() {
     document.getElementById('tdMeta').style.display = "none";
     document.getElementById('searchDiv').style.display = "none";
     document.getElementById('searchDiv_pl').style.display = "inline";
+    togglePlSearchHint(document.getElementById('selField_pl').value);
     document.getElementById('checkToggle').style.display = "none";
 	document.getElementById('pagination').style.display = "none";
     $("span[name=buttonRow]").hide();

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -318,6 +318,35 @@ $(function () {
                 });
     });
 
+    // Clear search button — Videos
+    $('#search').on('input', function() {
+        $('#searchClear').toggle(this.value !== '' && this.value !== 'Search Videos');
+    });
+
+    $('#searchClear').on('click', function() {
+        document.getElementById('search').value = '';
+        document.getElementById('selField').value = 'every_field';
+        $(this).hide();
+        searchVal = '';
+        searchField = 'every_field';
+        Load(getAllVideosURL());
+    });
+
+    // Clear search button — Playlists
+    $('#search_pl').on('input', function() {
+        $('#searchClear_pl').toggle(this.value !== '' && this.value !== 'Search Playlists');
+    });
+
+    $('#searchClear_pl').on('click', function() {
+        document.getElementById('search_pl').value = '';
+        document.getElementById('selField_pl').value = 'find_playlist_by_name';
+        $(this).hide();
+        togglePlSearchHint('find_playlist_by_name');
+        searchVal = '';
+        searchField = 'find_playlist_by_name';
+        Load(getAllPlaylistsURL());
+    });
+
 });
 
 function showPopup(title, message, btnPrimaryText, btnSecondaryText, onSuccess, onCancel) {
@@ -726,6 +755,7 @@ function buildMainVideoList(title) {
     document.getElementById('nameCol').innerHTML = "Video Name<span class='order'></span>";
     document.getElementById('headTitle').innerHTML = title;
     document.getElementById('search').value = searchVal ? searchVal : "Search Videos";
+    $('#searchClear').toggle(!!searchVal && searchVal !== 'Search Videos');
     document.getElementById('tdMeta').style.display = "none";
     document.getElementById('searchDiv').style.display = "inline";
     document.getElementById('searchDiv_pl').style.display = "none";
@@ -790,6 +820,7 @@ function buildPlaylistList() {
     document.getElementById('nameCol').innerHTML = "Playlist Name";
     document.getElementById('headTitle').innerHTML = "All Playlists";
     document.getElementById('search_pl').value = "Search Playlists";
+    $('#searchClear_pl').hide();
     document.getElementById('tdMeta').style.display = "none";
     document.getElementById('searchDiv').style.display = "none";
     document.getElementById('searchDiv_pl').style.display = "inline";
@@ -864,6 +895,7 @@ function showPlaylist() {
     document.getElementById('nameCol').innerHTML = "Video Name";
     document.getElementById('headTitle').innerHTML = oCurrentPlaylistList.name;
     document.getElementById('search').value = "Search Videos";
+    $('#searchClear').hide();
     document.getElementById('searchDiv').style.display = "inline"
     document.getElementById('searchDiv_pl').style.display = "none";
 

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-variant-dialog/.content.xml
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-variant-dialog/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    allowProxy="{Boolean}true"
+    categories="[dam.gui.assetdetails.coral]"/>

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-variant-dialog/.content.xml
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-variant-dialog/.content.xml
@@ -2,4 +2,4 @@
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:ClientLibraryFolder"
     allowProxy="{Boolean}true"
-    categories="[dam.gui.assetdetails.coral]"/>
+    categories="[dam.gui.admin.coral,dam.gui.assetdetails.coral]"/>

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-variant-dialog/js.txt
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-variant-dialog/js.txt
@@ -1,0 +1,2 @@
+#base=js
+variant-dialog.js

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-variant-dialog/js/variant-dialog.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-variant-dialog/js/variant-dialog.js
@@ -1,9 +1,10 @@
 (function (document, $) {
     "use strict";
 
-    var currentMode;    // 'add' or 'edit'
+    var currentMode;      // 'add' or 'edit'
     var currentVideoId;
-    var currentLanguage; // only used in edit mode
+    var currentAccountId;
+    var currentLanguage;  // only used in edit mode
 
     // ── Data helpers ──────────────────────────────────────────────────────────
 
@@ -48,12 +49,13 @@
 
     // ── Open add ──────────────────────────────────────────────────────────────
 
-    function openAddDialog(videoId) {
+    function openAddDialog(videoId, accountId) {
         var dlg = document.getElementById("brc-variant-dialog");
         if (!dlg) return;
 
-        currentMode    = "add";
-        currentVideoId = videoId;
+        currentMode      = "add";
+        currentVideoId   = videoId;
+        currentAccountId = accountId;
 
         dlg.querySelector("coral-dialog-header").textContent = "Add Variant";
 
@@ -66,13 +68,14 @@
 
     // ── Open edit ─────────────────────────────────────────────────────────────
 
-    function openEditDialog(videoId, language) {
+    function openEditDialog(videoId, accountId, language) {
         var dlg = document.getElementById("brc-variant-dialog");
         if (!dlg) return;
 
-        currentMode     = "edit";
-        currentVideoId  = videoId;
-        currentLanguage = language;
+        currentMode      = "edit";
+        currentVideoId   = videoId;
+        currentAccountId = accountId;
+        currentLanguage  = language;
 
         dlg.querySelector("coral-dialog-header").textContent = "Edit Variant";
 
@@ -129,6 +132,7 @@
             type: "POST",
             data: {
                 a:             currentMode === "add" ? "add_variant" : "update_variant",
+                account_id:    currentAccountId,
                 videoId:       currentVideoId,
                 language:      language,
                 name:          name,
@@ -137,14 +141,20 @@
                 custom_fields: JSON.stringify(customFields)
             },
             success: function (data) {
-                if (data && data.error && data.error !== null && data.error !== 0) {
+                // executePost puts the HTTP status code in data.error on success (200/201).
+                // Only treat it as a real error if it's a string (Brightcove error_code)
+                // or a number >= 400.
+                var errorVal = data && data.error;
+                var isError  = errorVal != null && errorVal !== 0 &&
+                               errorVal !== 200 && errorVal !== 201;
+                if (isError) {
                     showError(dlg, "Save failed. Check the language code and try again.");
                     return;
                 }
                 dlg.hide();
                 var variants = getVariantsData();
                 if (currentMode === "add") {
-                    addBadgeToDOM(language, currentVideoId);
+                    addBadgeToDOM(language, currentVideoId, currentAccountId);
                     variants.push({ language: language, name: name,
                         description: description, long_description: longDesc,
                         custom_fields: customFields });
@@ -169,7 +179,7 @@
 
     // ── DOM update after add ──────────────────────────────────────────────────
 
-    function addBadgeToDOM(language, videoId) {
+    function addBadgeToDOM(language, videoId, accountId) {
         var list = document.querySelector(".brc-variants-list");
         if (!list) return;
 
@@ -191,12 +201,13 @@
         editBtn.setAttribute("is", "coral-button");
         editBtn.setAttribute("variant", "minimal");
         editBtn.setAttribute("size", "S");
-        editBtn.className          = "brc-edit-variant-btn";
-        editBtn.dataset.language   = language;
+        editBtn.className            = "brc-edit-variant-btn";
+        editBtn.dataset.language     = language;
         editBtn.dataset.variantIndex = String(idx);
-        editBtn.dataset.videoId    = videoId;
-        editBtn.type               = "button";
-        editBtn.textContent        = "Edit";
+        editBtn.dataset.videoId      = videoId;
+        editBtn.dataset.accountId    = accountId;
+        editBtn.type                 = "button";
+        editBtn.textContent          = "Edit";
         badge.appendChild(editBtn);
 
         list.appendChild(badge);
@@ -206,12 +217,12 @@
 
     // Add variant
     $(document).on("click", ".brc-add-variant-btn", function () {
-        openAddDialog(this.dataset.videoId);
+        openAddDialog(this.dataset.videoId, this.dataset.accountId);
     });
 
     // Edit variant
     $(document).on("click", ".brc-edit-variant-btn", function () {
-        openEditDialog(this.dataset.videoId, this.dataset.language);
+        openEditDialog(this.dataset.videoId, this.dataset.accountId, this.dataset.language);
     });
 
     // Save (inside dialog)

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-variant-dialog/js/variant-dialog.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-variant-dialog/js/variant-dialog.js
@@ -1,0 +1,255 @@
+(function (document, $) {
+    "use strict";
+
+    var currentMode; // 'add' or 'edit'
+    var currentVideoId;
+    var currentLanguage; // only set in edit mode
+
+    function getVariantsData() {
+        var scriptEl = document.getElementById("brc-variants-data");
+        if (!scriptEl) return [];
+        try {
+            return JSON.parse(scriptEl.textContent);
+        } catch (e) {
+            return [];
+        }
+    }
+
+    function setVariantsData(variants) {
+        var scriptEl = document.getElementById("brc-variants-data");
+        if (scriptEl) scriptEl.textContent = JSON.stringify(variants);
+    }
+
+    function showError(dlg, message) {
+        var errorEl = dlg.querySelector("#brc-variant-error");
+        if (errorEl) {
+            errorEl.textContent = message;
+            errorEl.style.display = "block";
+        }
+    }
+
+    function clearError(dlg) {
+        var errorEl = dlg.querySelector("#brc-variant-error");
+        if (errorEl) {
+            errorEl.textContent = "";
+            errorEl.style.display = "none";
+        }
+    }
+
+    function clearForm(dlg) {
+        dlg.querySelector("#brc-variant-language").value = "";
+        dlg.querySelector("#brc-variant-name").value = "";
+        dlg.querySelector("#brc-variant-description").value = "";
+        dlg.querySelector("#brc-variant-long-description").value = "";
+        dlg.querySelectorAll(".brc-variant-cf").forEach(function (el) {
+            el.value = "";
+        });
+        clearError(dlg);
+    }
+
+    function openAddDialog(videoId) {
+        var dlg = document.getElementById("brc-variant-dialog");
+        if (!dlg) return;
+
+        currentMode = "add";
+        currentVideoId = videoId;
+
+        dlg.querySelector("coral-dialog-header").textContent = "Add Variant";
+
+        var langField = dlg.querySelector("#brc-variant-language");
+        langField.removeAttribute("readonly");
+        clearForm(dlg);
+        dlg.show();
+    }
+
+    function openEditDialog(videoId, language) {
+        var dlg = document.getElementById("brc-variant-dialog");
+        if (!dlg) return;
+
+        currentMode = "edit";
+        currentVideoId = videoId;
+        currentLanguage = language;
+
+        dlg.querySelector("coral-dialog-header").textContent = "Edit Variant";
+
+        clearForm(dlg);
+
+        // Language is read-only in edit mode
+        var langField = dlg.querySelector("#brc-variant-language");
+        langField.value = language;
+        langField.setAttribute("readonly", "readonly");
+
+        // Populate from stored variant data
+        var variants = getVariantsData();
+        var variant = null;
+        for (var i = 0; i < variants.length; i++) {
+            if (variants[i].language === language) {
+                variant = variants[i];
+                break;
+            }
+        }
+
+        if (variant) {
+            dlg.querySelector("#brc-variant-name").value = variant.name || "";
+            dlg.querySelector("#brc-variant-description").value = variant.description || "";
+            dlg.querySelector("#brc-variant-long-description").value = variant.long_description || "";
+            var customFields = variant.custom_fields || {};
+            dlg.querySelectorAll(".brc-variant-cf").forEach(function (el) {
+                var cfId = el.dataset.cfId;
+                if (cfId && customFields[cfId] != null) {
+                    el.value = customFields[cfId];
+                }
+            });
+        }
+
+        dlg.show();
+    }
+
+    function buildCustomFieldsObject(dlg) {
+        var obj = {};
+        dlg.querySelectorAll(".brc-variant-cf").forEach(function (el) {
+            var cfId = el.dataset.cfId;
+            if (cfId) obj[cfId] = el.value || "";
+        });
+        return obj;
+    }
+
+    function addBadgeToDOM(language, videoId) {
+        var list = document.querySelector(".brc-variants-list");
+        if (!list) return;
+
+        // Remove the "no variants" placeholder if present
+        var placeholder = list.querySelector(".coral-Form-fielddescription");
+        if (placeholder) placeholder.remove();
+
+        var idx = list.querySelectorAll(".brc-variant-badge").length;
+
+        var badge = document.createElement("span");
+        badge.className = "brc-variant-badge";
+        badge.style.cssText = "display:inline-flex;align-items:center;gap:6px;padding:4px 10px;background:#e8f0fe;border-radius:14px;font-size:12px;";
+
+        var langSpan = document.createElement("span");
+        langSpan.className = "brc-variant-language";
+        langSpan.textContent = language;
+        badge.appendChild(langSpan);
+
+        var editBtn = document.createElement("button");
+        editBtn.setAttribute("is", "coral-button");
+        editBtn.setAttribute("variant", "minimal");
+        editBtn.setAttribute("size", "S");
+        editBtn.className = "brc-edit-variant-btn";
+        editBtn.dataset.language = language;
+        editBtn.dataset.variantIndex = String(idx);
+        editBtn.dataset.videoId = videoId;
+        editBtn.type = "button";
+        editBtn.textContent = "Edit";
+        badge.appendChild(editBtn);
+
+        list.appendChild(badge);
+
+        editBtn.addEventListener("click", function () {
+            openEditDialog(this.dataset.videoId, this.dataset.language);
+        });
+    }
+
+    function handleSave() {
+        var dlg = document.getElementById("brc-variant-dialog");
+        if (!dlg) return;
+
+        clearError(dlg);
+
+        var language = dlg.querySelector("#brc-variant-language").value.trim();
+        if (!language) {
+            showError(dlg, "Language code is required.");
+            return;
+        }
+
+        var name          = dlg.querySelector("#brc-variant-name").value.trim();
+        var description   = dlg.querySelector("#brc-variant-description").value.trim();
+        var longDesc      = dlg.querySelector("#brc-variant-long-description").value.trim();
+        var customFields  = buildCustomFieldsObject(dlg);
+        var action        = currentMode === "add" ? "add_variant" : "update_variant";
+
+        Granite.$.ajax({
+            url: "/bin/brightcove/api.json",
+            type: "POST",
+            data: {
+                a: action,
+                videoId: currentVideoId,
+                language: language,
+                name: name,
+                description: description,
+                long_description: longDesc,
+                custom_fields: JSON.stringify(customFields)
+            },
+            success: function (data) {
+                if (data && data.error && data.error !== null && data.error !== 0) {
+                    showError(dlg, "Save failed. Please check the language code and try again.");
+                    return;
+                }
+                dlg.hide();
+                if (currentMode === "add") {
+                    addBadgeToDOM(language, currentVideoId);
+                    var variants = getVariantsData();
+                    variants.push({
+                        language: language,
+                        name: name,
+                        description: description,
+                        long_description: longDesc,
+                        custom_fields: customFields
+                    });
+                    setVariantsData(variants);
+                } else {
+                    // Update the in-memory data so subsequent edits see fresh values
+                    var variants = getVariantsData();
+                    for (var i = 0; i < variants.length; i++) {
+                        if (variants[i].language === currentLanguage) {
+                            variants[i].name = name;
+                            variants[i].description = description;
+                            variants[i].long_description = longDesc;
+                            variants[i].custom_fields = customFields;
+                            break;
+                        }
+                    }
+                    setVariantsData(variants);
+                }
+            },
+            error: function () {
+                showError(dlg, "An error occurred. Please try again.");
+            }
+        });
+    }
+
+    function bindButtons() {
+        var saveBtn = document.getElementById("brc-variant-save");
+        if (saveBtn && !saveBtn.dataset.brcBound) {
+            saveBtn.dataset.brcBound = "1";
+            saveBtn.addEventListener("click", handleSave);
+        }
+
+        document.querySelectorAll(".brc-add-variant-btn").forEach(function (btn) {
+            if (!btn.dataset.brcBound) {
+                btn.dataset.brcBound = "1";
+                btn.addEventListener("click", function () {
+                    openAddDialog(this.dataset.videoId);
+                });
+            }
+        });
+
+        document.querySelectorAll(".brc-edit-variant-btn").forEach(function (btn) {
+            if (!btn.dataset.brcBound) {
+                btn.dataset.brcBound = "1";
+                btn.addEventListener("click", function () {
+                    openEditDialog(this.dataset.videoId, this.dataset.language);
+                });
+            }
+        });
+    }
+
+    $(document).on("foundation-contentloaded", function () {
+        Coral.commons.ready(function () {
+            bindButtons();
+        });
+    });
+
+}(document, Granite.$));

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-variant-dialog/js/variant-dialog.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-variant-dialog/js/variant-dialog.js
@@ -1,39 +1,33 @@
 (function (document, $) {
     "use strict";
 
-    var currentMode; // 'add' or 'edit'
+    var currentMode;    // 'add' or 'edit'
     var currentVideoId;
-    var currentLanguage; // only set in edit mode
+    var currentLanguage; // only used in edit mode
+
+    // ── Data helpers ──────────────────────────────────────────────────────────
 
     function getVariantsData() {
-        var scriptEl = document.getElementById("brc-variants-data");
-        if (!scriptEl) return [];
-        try {
-            return JSON.parse(scriptEl.textContent);
-        } catch (e) {
-            return [];
-        }
+        var el = document.getElementById("brc-variants-data");
+        if (!el) return [];
+        try { return JSON.parse(el.textContent); } catch (e) { return []; }
     }
 
     function setVariantsData(variants) {
-        var scriptEl = document.getElementById("brc-variants-data");
-        if (scriptEl) scriptEl.textContent = JSON.stringify(variants);
+        var el = document.getElementById("brc-variants-data");
+        if (el) el.textContent = JSON.stringify(variants);
     }
 
-    function showError(dlg, message) {
-        var errorEl = dlg.querySelector("#brc-variant-error");
-        if (errorEl) {
-            errorEl.textContent = message;
-            errorEl.style.display = "block";
-        }
+    // ── Dialog helpers ────────────────────────────────────────────────────────
+
+    function showError(dlg, msg) {
+        var el = dlg.querySelector("#brc-variant-error");
+        if (el) { el.textContent = msg; el.style.display = "block"; }
     }
 
     function clearError(dlg) {
-        var errorEl = dlg.querySelector("#brc-variant-error");
-        if (errorEl) {
-            errorEl.textContent = "";
-            errorEl.style.display = "none";
-        }
+        var el = dlg.querySelector("#brc-variant-error");
+        if (el) { el.textContent = ""; el.style.display = "none"; }
     }
 
     function clearForm(dlg) {
@@ -41,116 +35,73 @@
         dlg.querySelector("#brc-variant-name").value = "";
         dlg.querySelector("#brc-variant-description").value = "";
         dlg.querySelector("#brc-variant-long-description").value = "";
-        dlg.querySelectorAll(".brc-variant-cf").forEach(function (el) {
-            el.value = "";
-        });
+        dlg.querySelectorAll(".brc-variant-cf").forEach(function (el) { el.value = ""; });
         clearError(dlg);
     }
+
+    function showDialog(dlg) {
+        // Wait for the specific coral-dialog element to be upgraded before calling show()
+        Coral.commons.ready(dlg, function () {
+            dlg.show();
+        });
+    }
+
+    // ── Open add ──────────────────────────────────────────────────────────────
 
     function openAddDialog(videoId) {
         var dlg = document.getElementById("brc-variant-dialog");
         if (!dlg) return;
 
-        currentMode = "add";
+        currentMode    = "add";
         currentVideoId = videoId;
 
         dlg.querySelector("coral-dialog-header").textContent = "Add Variant";
 
-        var langField = dlg.querySelector("#brc-variant-language");
-        langField.removeAttribute("readonly");
         clearForm(dlg);
-        dlg.show();
+        dlg.querySelector("#brc-variant-language").removeAttribute("readonly");
+
+        showDialog(dlg);
     }
+
+    // ── Open edit ─────────────────────────────────────────────────────────────
 
     function openEditDialog(videoId, language) {
         var dlg = document.getElementById("brc-variant-dialog");
         if (!dlg) return;
 
-        currentMode = "edit";
-        currentVideoId = videoId;
+        currentMode     = "edit";
+        currentVideoId  = videoId;
         currentLanguage = language;
 
         dlg.querySelector("coral-dialog-header").textContent = "Edit Variant";
 
         clearForm(dlg);
 
-        // Language is read-only in edit mode
         var langField = dlg.querySelector("#brc-variant-language");
         langField.value = language;
         langField.setAttribute("readonly", "readonly");
 
-        // Populate from stored variant data
         var variants = getVariantsData();
-        var variant = null;
+        var variant  = null;
         for (var i = 0; i < variants.length; i++) {
-            if (variants[i].language === language) {
-                variant = variants[i];
-                break;
-            }
+            if (variants[i].language === language) { variant = variants[i]; break; }
         }
 
         if (variant) {
-            dlg.querySelector("#brc-variant-name").value = variant.name || "";
-            dlg.querySelector("#brc-variant-description").value = variant.description || "";
+            dlg.querySelector("#brc-variant-name").value         = variant.name          || "";
+            dlg.querySelector("#brc-variant-description").value  = variant.description   || "";
             dlg.querySelector("#brc-variant-long-description").value = variant.long_description || "";
-            var customFields = variant.custom_fields || {};
+            var cf = variant.custom_fields || {};
             dlg.querySelectorAll(".brc-variant-cf").forEach(function (el) {
-                var cfId = el.dataset.cfId;
-                if (cfId && customFields[cfId] != null) {
-                    el.value = customFields[cfId];
-                }
+                var id = el.dataset.cfId;
+                if (id && cf[id] != null) el.value = cf[id];
             });
         }
 
-        dlg.show();
+        showDialog(dlg);
     }
 
-    function buildCustomFieldsObject(dlg) {
-        var obj = {};
-        dlg.querySelectorAll(".brc-variant-cf").forEach(function (el) {
-            var cfId = el.dataset.cfId;
-            if (cfId) obj[cfId] = el.value || "";
-        });
-        return obj;
-    }
-
-    function addBadgeToDOM(language, videoId) {
-        var list = document.querySelector(".brc-variants-list");
-        if (!list) return;
-
-        // Remove the "no variants" placeholder if present
-        var placeholder = list.querySelector(".coral-Form-fielddescription");
-        if (placeholder) placeholder.remove();
-
-        var idx = list.querySelectorAll(".brc-variant-badge").length;
-
-        var badge = document.createElement("span");
-        badge.className = "brc-variant-badge";
-        badge.style.cssText = "display:inline-flex;align-items:center;gap:6px;padding:4px 10px;background:#e8f0fe;border-radius:14px;font-size:12px;";
-
-        var langSpan = document.createElement("span");
-        langSpan.className = "brc-variant-language";
-        langSpan.textContent = language;
-        badge.appendChild(langSpan);
-
-        var editBtn = document.createElement("button");
-        editBtn.setAttribute("is", "coral-button");
-        editBtn.setAttribute("variant", "minimal");
-        editBtn.setAttribute("size", "S");
-        editBtn.className = "brc-edit-variant-btn";
-        editBtn.dataset.language = language;
-        editBtn.dataset.variantIndex = String(idx);
-        editBtn.dataset.videoId = videoId;
-        editBtn.type = "button";
-        editBtn.textContent = "Edit";
-        badge.appendChild(editBtn);
-
-        list.appendChild(badge);
-
-        editBtn.addEventListener("click", function () {
-            openEditDialog(this.dataset.videoId, this.dataset.language);
-        });
-    }
+    // ── Save ──────────────────────────────────────────────────────────────────
 
     function handleSave() {
         var dlg = document.getElementById("brc-variant-dialog");
@@ -159,49 +110,43 @@
         clearError(dlg);
 
         var language = dlg.querySelector("#brc-variant-language").value.trim();
-        if (!language) {
-            showError(dlg, "Language code is required.");
-            return;
-        }
+        if (!language) { showError(dlg, "Language code is required."); return; }
 
-        var name          = dlg.querySelector("#brc-variant-name").value.trim();
-        var description   = dlg.querySelector("#brc-variant-description").value.trim();
-        var longDesc      = dlg.querySelector("#brc-variant-long-description").value.trim();
-        var customFields  = buildCustomFieldsObject(dlg);
-        var action        = currentMode === "add" ? "add_variant" : "update_variant";
+        var name        = dlg.querySelector("#brc-variant-name").value.trim();
+        var description = dlg.querySelector("#brc-variant-description").value.trim();
+        var longDesc    = dlg.querySelector("#brc-variant-long-description").value.trim();
+
+        var customFields = {};
+        dlg.querySelectorAll(".brc-variant-cf").forEach(function (el) {
+            var id = el.dataset.cfId;
+            if (id) customFields[id] = el.value || "";
+        });
 
         Granite.$.ajax({
             url: "/bin/brightcove/api.json",
             type: "POST",
             data: {
-                a: action,
-                videoId: currentVideoId,
-                language: language,
-                name: name,
-                description: description,
+                a:             currentMode === "add" ? "add_variant" : "update_variant",
+                videoId:       currentVideoId,
+                language:      language,
+                name:          name,
+                description:   description,
                 long_description: longDesc,
                 custom_fields: JSON.stringify(customFields)
             },
             success: function (data) {
                 if (data && data.error && data.error !== null && data.error !== 0) {
-                    showError(dlg, "Save failed. Please check the language code and try again.");
+                    showError(dlg, "Save failed. Check the language code and try again.");
                     return;
                 }
                 dlg.hide();
+                var variants = getVariantsData();
                 if (currentMode === "add") {
                     addBadgeToDOM(language, currentVideoId);
-                    var variants = getVariantsData();
-                    variants.push({
-                        language: language,
-                        name: name,
-                        description: description,
-                        long_description: longDesc,
-                        custom_fields: customFields
-                    });
-                    setVariantsData(variants);
+                    variants.push({ language: language, name: name,
+                        description: description, long_description: longDesc,
+                        custom_fields: customFields });
                 } else {
-                    // Update the in-memory data so subsequent edits see fresh values
-                    var variants = getVariantsData();
                     for (var i = 0; i < variants.length; i++) {
                         if (variants[i].language === currentLanguage) {
                             variants[i].name = name;
@@ -211,8 +156,8 @@
                             break;
                         }
                     }
-                    setVariantsData(variants);
                 }
+                setVariantsData(variants);
             },
             error: function () {
                 showError(dlg, "An error occurred. Please try again.");
@@ -220,36 +165,54 @@
         });
     }
 
-    function bindButtons() {
-        var saveBtn = document.getElementById("brc-variant-save");
-        if (saveBtn && !saveBtn.dataset.brcBound) {
-            saveBtn.dataset.brcBound = "1";
-            saveBtn.addEventListener("click", handleSave);
-        }
+    // ── DOM update after add ──────────────────────────────────────────────────
 
-        document.querySelectorAll(".brc-add-variant-btn").forEach(function (btn) {
-            if (!btn.dataset.brcBound) {
-                btn.dataset.brcBound = "1";
-                btn.addEventListener("click", function () {
-                    openAddDialog(this.dataset.videoId);
-                });
-            }
-        });
+    function addBadgeToDOM(language, videoId) {
+        var list = document.querySelector(".brc-variants-list");
+        if (!list) return;
 
-        document.querySelectorAll(".brc-edit-variant-btn").forEach(function (btn) {
-            if (!btn.dataset.brcBound) {
-                btn.dataset.brcBound = "1";
-                btn.addEventListener("click", function () {
-                    openEditDialog(this.dataset.videoId, this.dataset.language);
-                });
-            }
-        });
+        var placeholder = list.querySelector(".coral-Form-fielddescription");
+        if (placeholder) placeholder.remove();
+
+        var idx = list.querySelectorAll(".brc-variant-badge").length;
+
+        var badge    = document.createElement("span");
+        badge.className  = "brc-variant-badge";
+        badge.style.cssText = "display:inline-flex;align-items:center;gap:6px;padding:4px 10px;background:#e8f0fe;border-radius:14px;font-size:12px;";
+
+        var langSpan = document.createElement("span");
+        langSpan.className   = "brc-variant-language";
+        langSpan.textContent = language;
+        badge.appendChild(langSpan);
+
+        var editBtn = document.createElement("button");
+        editBtn.setAttribute("is", "coral-button");
+        editBtn.setAttribute("variant", "minimal");
+        editBtn.setAttribute("size", "S");
+        editBtn.className          = "brc-edit-variant-btn";
+        editBtn.dataset.language   = language;
+        editBtn.dataset.variantIndex = String(idx);
+        editBtn.dataset.videoId    = videoId;
+        editBtn.type               = "button";
+        editBtn.textContent        = "Edit";
+        badge.appendChild(editBtn);
+
+        list.appendChild(badge);
     }
 
-    $(document).on("foundation-contentloaded", function () {
-        Coral.commons.ready(function () {
-            bindButtons();
-        });
+    // ── Event binding (delegation — works regardless of load timing) ──────────
+
+    // Add variant
+    $(document).on("click", ".brc-add-variant-btn", function () {
+        openAddDialog(this.dataset.videoId);
     });
+
+    // Edit variant
+    $(document).on("click", ".brc-edit-variant-btn", function () {
+        openEditDialog(this.dataset.videoId, this.dataset.language);
+    });
+
+    // Save (inside dialog)
+    $(document).on("click", "#brc-variant-save", handleSave);
 
 }(document, Granite.$));

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-variant-dialog/js/variant-dialog.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-variant-dialog/js/variant-dialog.js
@@ -59,6 +59,7 @@
 
         clearForm(dlg);
         dlg.querySelector("#brc-variant-language").removeAttribute("readonly");
+        dlg.querySelector("#brc-variant-language").removeAttribute("disabled");
 
         showDialog(dlg);
     }
@@ -80,6 +81,7 @@
         var langField = dlg.querySelector("#brc-variant-language");
         langField.value = language;
         langField.setAttribute("readonly", "readonly");
+        langField.setAttribute("disabled", "disabled");
 
         var variants = getVariantsData();
         var variant  = null;

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-variant-dialog/js/variant-dialog.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-variant-dialog/js/variant-dialog.js
@@ -170,9 +170,34 @@
                     }
                 }
                 setVariantsData(variants);
+                persistVariantsToJcr(variants);
             },
             error: function () {
                 showError(dlg, "An error occurred. Please try again.");
+            }
+        });
+    }
+
+    // ── JCR persistence ───────────────────────────────────────────────────────
+
+    function persistVariantsToJcr(variants) {
+        var section = document.querySelector(".brc-variants-section");
+        if (!section || !section.dataset.assetPath) return;
+
+        // Sling POST multi-value String[]: send each element as a separate
+        // brc_variants param alongside the @TypeHint hint.
+        // traditional:true prevents jQuery from appending [0],[1] indices.
+        Granite.$.ajax({
+            url: section.dataset.assetPath + "/jcr:content/metadata",
+            type: "POST",
+            traditional: true,
+            data: {
+                "brc_variants":          variants.map(function (v) { return JSON.stringify(v); }),
+                "brc_variants@TypeHint": "String[]"
+            },
+            error: function () {
+                // Non-fatal — the change already exists in Brightcove and
+                // JCR will be updated on the next scheduled sync.
             }
         });
     }

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-variant-dialog/js/variant-dialog.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-variant-dialog/js/variant-dialog.js
@@ -202,6 +202,57 @@
         });
     }
 
+    // ── Delete ────────────────────────────────────────────────────────────────
+
+    function handleDelete(videoId, accountId, language) {
+        if (!window.confirm("Delete the \"" + language + "\" variant? This cannot be undone.")) return;
+
+        Granite.$.ajax({
+            url: "/bin/brightcove/api.json",
+            type: "POST",
+            data: {
+                a:          "delete_variant",
+                account_id: accountId,
+                videoId:    videoId,
+                language:   language
+            },
+            success: function (data) {
+                var errorVal = data && data.error;
+                var isError  = errorVal != null && errorVal !== 0 &&
+                               errorVal !== 200 && errorVal !== 204;
+                if (isError) {
+                    window.alert("Delete failed. Please try again.");
+                    return;
+                }
+                // Remove badge from DOM
+                var list = document.querySelector(".brc-variants-list");
+                if (list) {
+                    var badges = list.querySelectorAll(".brc-variant-badge");
+                    for (var i = 0; i < badges.length; i++) {
+                        var langEl = badges[i].querySelector(".brc-variant-language");
+                        if (langEl && langEl.textContent === language) {
+                            badges[i].remove();
+                            break;
+                        }
+                    }
+                    if (list.querySelectorAll(".brc-variant-badge").length === 0) {
+                        var empty = document.createElement("span");
+                        empty.className   = "coral-Form-fielddescription";
+                        empty.textContent = "No variants configured.";
+                        list.appendChild(empty);
+                    }
+                }
+                // Update in-memory store and persist to JCR
+                var variants = getVariantsData().filter(function (v) { return v.language !== language; });
+                setVariantsData(variants);
+                persistVariantsToJcr(variants);
+            },
+            error: function () {
+                window.alert("An error occurred. Please try again.");
+            }
+        });
+    }
+
     // ── DOM update after add ──────────────────────────────────────────────────
 
     function addBadgeToDOM(language, videoId, accountId) {
@@ -235,6 +286,18 @@
         editBtn.textContent          = "Edit";
         badge.appendChild(editBtn);
 
+        var delBtn = document.createElement("button");
+        delBtn.setAttribute("is", "coral-button");
+        delBtn.setAttribute("variant", "minimal");
+        delBtn.setAttribute("size", "S");
+        delBtn.className         = "brc-delete-variant-btn";
+        delBtn.dataset.language  = language;
+        delBtn.dataset.videoId   = videoId;
+        delBtn.dataset.accountId = accountId;
+        delBtn.type              = "button";
+        delBtn.textContent       = "Delete";
+        badge.appendChild(delBtn);
+
         list.appendChild(badge);
     }
 
@@ -248,6 +311,11 @@
     // Edit variant
     $(document).on("click", ".brc-edit-variant-btn", function () {
         openEditDialog(this.dataset.videoId, this.dataset.accountId, this.dataset.language);
+    });
+
+    // Delete variant
+    $(document).on("click", ".brc-delete-variant-btn", function () {
+        handleDelete(this.dataset.videoId, this.dataset.accountId, this.dataset.language);
     });
 
     // Save (inside dialog)

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/shared/autoDialog/autoDialog.jsp
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/shared/autoDialog/autoDialog.jsp
@@ -241,7 +241,7 @@
     </div>
 </div>
 
-<coral-dialog id="brc-variant-dialog" closable="on">
+<coral-dialog id="brc-variant-dialog" closable="on" size="L">
     <coral-dialog-header>Variant</coral-dialog-header>
     <coral-dialog-content>
         <div class="coral-Form coral-Form--vertical" style="padding:0;">

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/shared/autoDialog/autoDialog.jsp
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/shared/autoDialog/autoDialog.jsp
@@ -229,6 +229,12 @@
                         data-video-id="<%=brcid%>"
                         data-account-id="<%=org.apache.commons.lang3.StringEscapeUtils.escapeHtml4(map.get("brc_account_id",""))%>"
                         type="button">Edit</button>
+                <button is="coral-button" variant="minimal" size="S"
+                        class="brc-delete-variant-btn"
+                        data-language="<%=org.apache.commons.lang3.StringEscapeUtils.escapeHtml4(variantLang)%>"
+                        data-video-id="<%=brcid%>"
+                        data-account-id="<%=org.apache.commons.lang3.StringEscapeUtils.escapeHtml4(map.get("brc_account_id",""))%>"
+                        type="button">Delete</button>
             </span>
             <%
                     }

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/shared/autoDialog/autoDialog.jsp
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/shared/autoDialog/autoDialog.jsp
@@ -227,6 +227,7 @@
                         data-language="<%=org.apache.commons.lang3.StringEscapeUtils.escapeHtml4(variantLang)%>"
                         data-variant-index="<%=vIdx%>"
                         data-video-id="<%=brcid%>"
+                        data-account-id="<%=org.apache.commons.lang3.StringEscapeUtils.escapeHtml4(map.get("brc_account_id",""))%>"
                         type="button">Edit</button>
             </span>
             <%
@@ -237,6 +238,7 @@
         <button is="coral-button" variant="secondary" size="S"
                 class="brc-add-variant-btn"
                 data-video-id="<%=brcid%>"
+                data-account-id="<%=org.apache.commons.lang3.StringEscapeUtils.escapeHtml4(map.get("brc_account_id",""))%>"
                 type="button">+ Add Variant</button>
     </div>
 </div>

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/shared/autoDialog/autoDialog.jsp
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/shared/autoDialog/autoDialog.jsp
@@ -72,6 +72,8 @@
 
         Resource custom_fields = metadataRes.getChild("brc_custom_fields");
         ValueMap custom_map = custom_fields != null ? custom_fields.adaptTo(ValueMap.class) : null;
+
+        String[] brcVariantsRaw = map.get("brc_variants", new String[0]);
 %>
 
     <div  class="aem-assets-metadata-form-column">
@@ -190,6 +192,45 @@
     </div>
     <div class="foundation-field-editable">
         <div  class="coral-Form-fieldwrapper foundation-field-edit"><label class="coral-Form-fieldlabel">Duration</label><input  class="coral-Form-field" disabled="" data-metaType="text" type="text" name="./jcr:content/metadata/brc_duration" value="<%=map.get("brc_duration","")%>" data-foundation-validation="" data-validation="" is="coral-textfield"></div>
+    </div>
+</div>
+
+<div class="aem-assets-metadata-form-column brc-variants-section" style="width:100%;margin-top:16px;">
+    <div class="coral-Form-fieldwrapper">
+        <label class="coral-Form-fieldlabel">Variants</label>
+        <div class="brc-variants-list" style="display:flex;flex-wrap:wrap;gap:8px;margin-bottom:8px;">
+            <%
+                if (brcVariantsRaw.length == 0) {
+            %>
+            <span class="coral-Form-fielddescription">No variants configured.</span>
+            <%
+                } else {
+                    for (int vIdx = 0; vIdx < brcVariantsRaw.length; vIdx++) {
+                        String variantLang = "";
+                        try {
+                            JSONObject variantObj = new JSONObject(brcVariantsRaw[vIdx]);
+                            variantLang = variantObj.optString("language", "");
+                        } catch (Exception ex) { /* skip malformed entry */ }
+                        if (variantLang.isEmpty()) continue;
+            %>
+            <span class="brc-variant-badge" style="display:inline-flex;align-items:center;gap:6px;padding:4px 10px;background:#e8f0fe;border-radius:14px;font-size:12px;">
+                <span class="brc-variant-language"><%=variantLang%></span>
+                <button is="coral-button" variant="minimal" size="S"
+                        class="brc-edit-variant-btn"
+                        data-language="<%=variantLang%>"
+                        data-variant-index="<%=vIdx%>"
+                        data-video-id="<%=brcid%>"
+                        type="button">Edit</button>
+            </span>
+            <%
+                    }
+                }
+            %>
+        </div>
+        <button is="coral-button" variant="secondary" size="S"
+                class="brc-add-variant-btn"
+                data-video-id="<%=brcid%>"
+                type="button">+ Add Variant</button>
     </div>
 </div>
 <%

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/shared/autoDialog/autoDialog.jsp
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/shared/autoDialog/autoDialog.jsp
@@ -75,6 +75,13 @@
 
         String[] brcVariantsRaw = map.get("brc_variants", new String[0]);
 %>
+<script type="application/json" id="brc-variants-data">[<%
+    for (int bvIdx = 0; bvIdx < brcVariantsRaw.length; bvIdx++) {
+        if (bvIdx > 0) out.print(",");
+        String bv = brcVariantsRaw[bvIdx];
+        out.print((bv != null && !bv.isEmpty()) ? bv : "{}");
+    }
+%>]</script>
 
     <div  class="aem-assets-metadata-form-column">
         <div class="foundation-field-editable">
@@ -214,10 +221,10 @@
                         if (variantLang.isEmpty()) continue;
             %>
             <span class="brc-variant-badge" style="display:inline-flex;align-items:center;gap:6px;padding:4px 10px;background:#e8f0fe;border-radius:14px;font-size:12px;">
-                <span class="brc-variant-language"><%=variantLang%></span>
+                <span class="brc-variant-language"><%=org.apache.commons.lang3.StringEscapeUtils.escapeHtml4(variantLang)%></span>
                 <button is="coral-button" variant="minimal" size="S"
                         class="brc-edit-variant-btn"
-                        data-language="<%=variantLang%>"
+                        data-language="<%=org.apache.commons.lang3.StringEscapeUtils.escapeHtml4(variantLang)%>"
                         data-variant-index="<%=vIdx%>"
                         data-video-id="<%=brcid%>"
                         type="button">Edit</button>
@@ -233,6 +240,67 @@
                 type="button">+ Add Variant</button>
     </div>
 </div>
+
+<coral-dialog id="brc-variant-dialog" closable="on">
+    <coral-dialog-header>Variant</coral-dialog-header>
+    <coral-dialog-content>
+        <div class="coral-Form coral-Form--vertical" style="padding:0;">
+            <div id="brc-variant-error" style="display:none;color:#d9534f;margin-bottom:8px;"></div>
+            <div class="coral-Form-fieldwrapper">
+                <label class="coral-Form-fieldlabel" for="brc-variant-language">Language Code <span style="color:#d9534f;">*</span></label>
+                <input id="brc-variant-language" is="coral-textfield" class="coral-Form-field" type="text" placeholder="e.g. fr, de, es">
+            </div>
+            <div class="coral-Form-fieldwrapper">
+                <label class="coral-Form-fieldlabel" for="brc-variant-name">Name</label>
+                <input id="brc-variant-name" is="coral-textfield" class="coral-Form-field" type="text">
+            </div>
+            <div class="coral-Form-fieldwrapper">
+                <label class="coral-Form-fieldlabel" for="brc-variant-description">Short Description</label>
+                <input id="brc-variant-description" is="coral-textfield" class="coral-Form-field" type="text" maxlength="250">
+            </div>
+            <div class="coral-Form-fieldwrapper">
+                <label class="coral-Form-fieldlabel" for="brc-variant-long-description">Long Description</label>
+                <textarea id="brc-variant-long-description" is="coral-textarea" class="coral-Form-field" maxlength="5000"></textarea>
+            </div>
+            <%
+                if (custom_fields_arr.length() > 0) {
+                    for (int dlgZ = 0; dlgZ < custom_fields_arr.length(); dlgZ++) {
+                        JSONObject dlgCf = custom_fields_arr.getJSONObject(dlgZ);
+                        String dlgFieldTitle = dlgCf.getString("display_name");
+                        String dlgFieldId    = dlgCf.getString("id");
+                        String dlgFieldType  = dlgCf.getString("type");
+                        boolean dlgRequired  = dlgCf.getBoolean("required");
+                        if (dlgFieldType.equals("enum")) {
+                            JSONArray dlgEnums = dlgCf.getJSONArray("enum_values");
+            %>
+            <div class="coral-Form-fieldwrapper">
+                <label class="coral-Form-fieldlabel"><b><%=dlgFieldTitle%><%=dlgRequired ? " *":""%></b></label>
+                <coral-select class="coral-Form-field brc-variant-cf" data-cf-id="<%=dlgFieldId%>">
+                    <coral-select-item value=""></coral-select-item>
+                    <% for (int dlgX = 0; dlgX < dlgEnums.length(); dlgX++) { %>
+                    <coral-select-item value="<%=dlgEnums.getString(dlgX)%>"><%=dlgEnums.getString(dlgX)%></coral-select-item>
+                    <% } %>
+                </coral-select>
+            </div>
+            <%
+                        } else {
+            %>
+            <div class="coral-Form-fieldwrapper">
+                <label class="coral-Form-fieldlabel"><b><%=dlgFieldTitle%><%=dlgRequired ? " *":""%></b></label>
+                <input is="coral-textfield" class="coral-Form-field brc-variant-cf" type="text" data-cf-id="<%=dlgFieldId%>">
+            </div>
+            <%
+                        }
+                    }
+                }
+            %>
+        </div>
+    </coral-dialog-content>
+    <coral-dialog-footer>
+        <button is="coral-button" variant="default" coral-close type="button">Cancel</button>
+        <button id="brc-variant-save" is="coral-button" variant="primary" type="button">Save</button>
+    </coral-dialog-footer>
+</coral-dialog>
 <%
     } else {
 %>

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/shared/autoDialog/autoDialog.jsp
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/shared/autoDialog/autoDialog.jsp
@@ -202,7 +202,7 @@
     </div>
 </div>
 
-<div class="aem-assets-metadata-form-column brc-variants-section" style="width:100%;margin-top:16px;">
+<div class="aem-assets-metadata-form-column brc-variants-section" data-asset-path="<%=org.apache.commons.lang3.StringEscapeUtils.escapeHtml4(asset_res.getPath())%>" style="width:100%;margin-top:16px;">
     <div class="coral-Form-fieldwrapper">
         <label class="coral-Form-fieldlabel">Variants</label>
         <div class="brc-variants-list" style="display:flex;flex-wrap:wrap;gap:8px;margin-bottom:8px;">

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/shared/autoDialog/autoDialog.jsp
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/shared/autoDialog/autoDialog.jsp
@@ -60,11 +60,15 @@
         }
 
 
-        ServiceUtil serviceUtil = new ServiceUtil(requestedAccount);
-
-
-        JSONObject custom_fields_obj = serviceUtil.getCustomFields();
-        JSONArray custom_fields_arr = custom_fields_obj.getJSONArray("custom_fields");
+        JSONArray custom_fields_arr = new JSONArray();
+        try {
+            ServiceUtil serviceUtil = new ServiceUtil(requestedAccount);
+            JSONObject custom_fields_obj = new JSONObject(serviceUtil.getCustomFields().toString());
+            JSONArray fetched = custom_fields_obj.optJSONArray("custom_fields");
+            if (fetched != null) custom_fields_arr = fetched;
+        } catch (Exception e) {
+            // account not configured in this environment — render without custom fields
+        }
 
         Resource custom_fields = metadataRes.getChild("brc_custom_fields");
         ValueMap custom_map = custom_fields != null ? custom_fields.adaptTo(ValueMap.class) : null;

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
@@ -90,7 +90,7 @@
                                                 </select>
 
                                                 <div style="position:relative; display:inline-block;">
-                                                    <input id="search" type="text" value="Search Videos" onClick="this.value=''">
+                                                    <input id="search" type="text" value="Search Videos" onClick="if(this.value==='Search Videos') this.value='';">
                                                     <button type="button" id="searchClear" style="display:none;">&#x2715;</button>
                                                 </div>
                                                 <!--Store the search query in searchBut.value so we can use it as the title of the page once the results are returned.  See searchVideoCallBack -->
@@ -111,7 +111,7 @@
                                                     Create Playlist
                                                 </button>-->
                                                 <div style="position:relative; display:inline-block; top:5px; height:30px; margin-left:15px;">
-                                                    <input id="search_pl" type="text" value="Search Playlists" onClick="this.value=''" style="height:30px;">
+                                                    <input id="search_pl" type="text" value="Search Playlists" onClick="if(this.value==='Search Playlists') this.value='';" style="height:30px;">
                                                     <button type="button" id="searchClear_pl" style="display:none;">&#x2715;</button>
                                                 </div>
                                                 <!--Store the search query in searchBut.value so we can use it as the title of the page once the results are returned.  See searchVideoCallBack -->

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
@@ -111,8 +111,9 @@
                                                        style="position: relative;top: 5px; height: 30px; margin-left: 15px;">
                                                 <!--Store the search query in searchBut.value so we can use it as the title of the page once the results are returned.  See searchVideoCallBack -->
                                                 <select id='selField_pl' name="selField_pl" style="position: relative;top: 5px;">
-                                                    <option value="find_playlist_by_id">In Playlist ID</option>
-                                                    <option value="find_playlist_by_reference_id">In Reference ID</option>
+                                                    <option value="find_playlist_by_name">Name</option>
+                                                    <option value="find_playlist_by_id">Playlist ID</option>
+                                                    <option value="find_playlist_by_reference_id">Reference ID</option>
                                                 </select>
                                                 <button id="searchBut" onClick="searchVal=document.getElementById('search_pl').value;searchField=document.getElementById('selField_pl').value;Load(getFindPlaylistsURL())">
                                                     Search

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
@@ -89,7 +89,10 @@
                                                     <option value="all">All Folders</option>
                                                 </select>
 
-                                                <input id="search" type="text" value="Search Video" onClick="this.value=''">
+                                                <div style="position:relative; display:inline-block;">
+                                                    <input id="search" type="text" value="Search Videos" onClick="this.value=''">
+                                                    <button type="button" id="searchClear" style="display:none;">&#x2715;</button>
+                                                </div>
                                                 <!--Store the search query in searchBut.value so we can use it as the title of the page once the results are returned.  See searchVideoCallBack -->
                                                 <select id='selField' name="selField" >
                                                     <option value="every_field">In Every Field</option>
@@ -107,8 +110,10 @@
                                                 <!--<button id="searchBut" class="btn-create-playlist">
                                                     Create Playlist
                                                 </button>-->
-                                                <input id="search_pl" type="text" value="Search Playlists" onClick="this.value=''"
-                                                       style="position: relative;top: 5px; height: 30px; margin-left: 15px;">
+                                                <div style="position:relative; display:inline-block; top:5px; height:30px; margin-left:15px;">
+                                                    <input id="search_pl" type="text" value="Search Playlists" onClick="this.value=''" style="height:30px;">
+                                                    <button type="button" id="searchClear_pl" style="display:none;">&#x2715;</button>
+                                                </div>
                                                 <!--Store the search query in searchBut.value so we can use it as the title of the page once the results are returned.  See searchVideoCallBack -->
                                                 <select id='selField_pl' name="selField_pl" style="position: relative;top: 5px;" onchange="togglePlSearchHint(this.value)">
                                                     <option value="find_playlist_by_name">Name</option>

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
@@ -110,7 +110,7 @@
                                                 <input id="search_pl" type="text" value="Search Playlists" onClick="this.value=''"
                                                        style="position: relative;top: 5px; height: 30px; margin-left: 15px;">
                                                 <!--Store the search query in searchBut.value so we can use it as the title of the page once the results are returned.  See searchVideoCallBack -->
-                                                <select id='selField_pl' name="selField_pl" style="position: relative;top: 5px;">
+                                                <select id='selField_pl' name="selField_pl" style="position: relative;top: 5px;" onchange="togglePlSearchHint(this.value)">
                                                     <option value="find_playlist_by_name">Name</option>
                                                     <option value="find_playlist_by_id">Playlist ID</option>
                                                     <option value="find_playlist_by_reference_id">Reference ID</option>
@@ -118,6 +118,7 @@
                                                 <button id="searchBut" onClick="searchVal=document.getElementById('search_pl').value;searchField=document.getElementById('selField_pl').value;Load(getFindPlaylistsURL())">
                                                     Search
                                                 </button>
+                                                <div id="pl_search_hint" style="font-size:11px;color:#666;margin-top:4px;margin-left:15px;">Matches whole words only (e.g. "Smart" finds "Smart Playlist")</div>
                                             </div>
 
                                         </td>


### PR DESCRIPTION
## Summary

- **BCON-128**: Added X clear button to video and playlist search inputs; only clears on click when showing placeholder
- **BCON-129**: Display language variants as badges in the DAM asset Brightcove tab
- **BCON-130**: Fixed video player size and poster repeat/pixelation on DAM asset details page
- **BCON-131**: Added playlist search by name; fixed partial match support; added hint when name search is selected
- **BCON-152**: Full language variant CRUD via Coral UI dialog — add, edit, and delete variants with JCR persistence and Brightcove API sync

## Test plan

- [ ] Search inputs: X button clears input; only activates when placeholder text is showing
- [ ] Playlist search: name search returns partial matches; hint text appears when name mode is selected
- [ ] DAM asset details: video player renders at correct size with no poster pixelation/repeat
- [ ] Brightcove tab — variants section: existing variants display as language-code badges
- [ ] Add variant: opens dialog, saves to Brightcove, badge appears without page reload
- [ ] Edit variant: opens dialog pre-populated with existing values, updates Brightcove and badge in place
- [ ] Delete variant: confirm prompt shown, variant removed from Brightcove and badge removed from DOM
- [ ] Variants persist across page refresh (JCR `brc_variants` updated correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)