### PR TITLE
feat(BCON-121/141/142): Brightcove Admin header revamp + videos list + filter panel

### DIFF
--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -175,6 +175,99 @@ body {
   line-height: 1;
 }
 
+/* Account popover (Frame E) */
+.brc-account-popover {
+  position: absolute;
+  top: 100%;
+  right: 20px;
+  width: 240px;
+  background: #fff;
+  border: 1px solid #e8e6df;
+  border-radius: 10px;
+  overflow: hidden;
+  z-index: 1000;
+  box-shadow: 0 4px 16px rgba(26, 26, 24, 0.08);
+}
+
+.brc-account-popover[hidden] {
+  display: none;
+}
+
+.brc-account-popover-header {
+  height: 40px;
+  display: flex;
+  align-items: center;
+  padding: 0 14px;
+  background: #f0efea;
+  border-bottom: 1px solid #e8e6df;
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.66px;
+  text-transform: uppercase;
+  color: #1a1a18;
+}
+
+.brc-account-popover-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.brc-account-row {
+  position: relative;
+  display: block;
+  width: 100%;
+  padding: 12px 14px;
+  background: #fff;
+  border: none;
+  border-top: 1px solid #e8e6df;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+  -webkit-appearance: none;
+  appearance: none;
+  text-shadow: none;
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+.brc-account-row:first-child {
+  border-top: none;
+}
+
+.brc-account-row:hover:not(.is-active) {
+  background: #f7f6f2;
+}
+
+.brc-account-row.is-active {
+  background: #f7f6f2;
+  cursor: default;
+  padding-bottom: 12px;
+}
+
+.brc-account-row-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: #1a1a18;
+  line-height: 1.4;
+}
+
+.brc-account-row-id {
+  font-size: 12px;
+  font-weight: 400;
+  color: #6b7280;
+  line-height: 1.4;
+  margin-top: 2px;
+}
+
+.brc-account-row-status {
+  font-size: 12px;
+  font-weight: 500;
+  color: #6b7280;
+  line-height: 1.4;
+  margin-top: 4px;
+}
+
 a.home {
   cursor: pointer;
   display: block;

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -268,6 +268,43 @@ body {
   margin-top: 4px;
 }
 
+/* Toast (account switch confirmation) */
+.brc-toast {
+  position: fixed;
+  bottom: 32px;
+  left: 50%;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 18px;
+  background: #1a1a18;
+  color: #fff;
+  border-radius: 8px;
+  font-family: 'Inter', adobe-clean, Helvetica, Arial, sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+  opacity: 0;
+  transform: translate(-50%, 16px);
+  transition: opacity 0.18s ease, transform 0.22s ease;
+  z-index: 10000;
+  pointer-events: none;
+}
+
+.brc-toast.is-visible {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.brc-toast-icon {
+  display: inline-flex;
+  width: 16px;
+  height: 16px;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+}
+
 a.home {
   cursor: pointer;
   display: block;

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -1,5 +1,5 @@
 body {
-  background-color: #c3ddf6;
+  background-color: #fff;
   font-family: adobe-clean,Helvetica,Arial,sans-serif;
 }
 
@@ -18,48 +18,161 @@ body {
   z-index:999999;
 }
 
-.navbar {
-  background: #080886;
+/* ---- BCON-121: Header revamp ---- */
+.brc-header {
+  position: relative;
+  display: flex;
+  align-items: center;
+  background: #f0efea;
+  border-bottom: 1px solid #e8e6df;
+  padding: 0 20px;
+  height: 68px;
+  font-family: 'Inter', adobe-clean, Helvetica, Arial, sans-serif;
 }
 
-.navbar-inner {
-  padding: 7px 20px;
-  border-radius: 0px;
-  background: #080886;
-  -webkit-border-radius: 0px;
-  -moz-border-radius: 0px;
-  border-radius: 0px;
-  -webkit-box-shadow: 0px 2px 10px rgba(0, 0, 0, .11);
-  -moz-box-shadow: 0px 0px 10px rgba(0, 0, 0, .11);
-  -ms-box-shadow: 0px 2px 10px rgba(0, 0, 0, .11);
-  box-shadow: 0px 2px 10px rgba(0, 0, 0, .11);
-
+.brc-header *,
+.brc-header *::before,
+.brc-header *::after {
+  box-sizing: border-box;
 }
 
-.navbar .nav > li > a {
-  float: none;
-  padding: 9px 10px 11px;
-  line-height: 19px;
-  color: #fff;
-  text-decoration: none;
-  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
+.brc-tabs {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: #f0efea;
+  border-radius: 10px;
+  padding: 4px 3px;
+  height: 40px;
+}
+
+.brc-tab {
+  background: transparent;
+  border: none;
+  padding: 0 13px;
+  height: 32px;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 400;
+  color: #1a1a18;
+  border-radius: 8px;
   cursor: pointer;
-  text-transform: uppercase;
+  text-transform: none;
+  letter-spacing: normal;
+  line-height: 1;
+  text-shadow: none;
+  white-space: nowrap;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.brc-tab.is-active {
+  background: #fff;
+  border: 1px solid #e8e6df;
+  font-weight: 600;
+}
+
+.brc-title {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  margin: 0;
+  font-family: inherit;
+  font-size: 16px;
+  font-weight: 600;
+  color: #1a1a18;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+.brc-header-actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Override the shared button-style block (#syncdbutton, .btn, etc.) for the new black-filled sync button. */
+#syncdbutton.brc-sync-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 36px;
+  padding: 0 14px;
+  margin: 0;
+  background: #1a1a18;
+  background-image: none;
+  background-color: #1a1a18;
+  border: none;
+  border-radius: 8px;
+  color: #fff;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  text-transform: none;
+  text-shadow: none;
+  letter-spacing: normal;
+  cursor: pointer;
+  box-shadow: none;
+  filter: none;
+}
+
+#syncdbutton.brc-sync-btn:hover {
+  background: #2a2a26;
+  background-color: #2a2a26;
+  color: #fff;
+}
+
+.brc-sync-icon {
+  flex-shrink: 0;
+}
+
+.brc-account-trigger {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  height: 36px;
+  padding: 0 13px;
+  background: #fff;
+  border: 1px solid #e8e6df;
+  border-radius: 8px;
+  cursor: pointer;
+  user-select: none;
+  min-width: 192px;
+  font-family: inherit;
+}
+
+.brc-account-info {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
+  min-width: 0;
+}
+
+.brc-account-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: #1a1a18;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.brc-account-id {
   font-size: 11px;
-  font-weight: bold;
+  font-weight: 400;
+  color: #6b7280;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.navbar .nav > li > a:hover {
-  color: #ffffff;
-  text-decoration: none;
-  background-color: transparent;
-}
-
-.navbar .nav .active > a,
-.navbar .nav .active > a:hover {
-  color: #ffffff;
-  text-decoration: none;
-  background-color: rgba(255, 255, 255, 0.1);
+.brc-account-caret {
+  margin-left: auto;
+  font-size: 12px;
+  color: #6b7280;
+  line-height: 1;
 }
 
 a.home {
@@ -427,11 +540,13 @@ div.hLine {
 
 #brightcove {
   position: relative;
-  margin: 20px;
-  padding: 20px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.25);
+  margin: 0;
+  padding: 0;
   background: #fff;
-  top: 10px;
+}
+
+#divConsole {
+  padding: 0 20px 20px;
 }
 
 .foundation-layout-panel-content {

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -124,6 +124,12 @@ body {
   color: #fff;
 }
 
+#syncdbutton.brc-sync-btn.is-loading,
+#syncdbutton.brc-sync-btn[disabled] {
+  opacity: 0.7;
+  cursor: progress;
+}
+
 .brc-sync-icon {
   flex-shrink: 0;
 }

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -392,6 +392,23 @@ betty-titlebar {
   border-color: #d6d4cc;
 }
 
+/* Active-filter dot — added when any of label/folder/clips is non-default. */
+.brc-filter-btn.has-active-filters {
+  position: relative;
+}
+
+.brc-filter-btn.has-active-filters::after {
+  content: '';
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 8px;
+  height: 8px;
+  background: #1a1a18;
+  border: 1.5px solid #fff;
+  border-radius: 50%;
+}
+
 /* Bulk action bar (BCON-141, Frame C) */
 .brc-bulk-bar {
   display: inline-flex;
@@ -637,6 +654,45 @@ betty-titlebar {
   width: 15px;
   height: 15px;
   margin: 0;
+}
+
+.brc-filter-section--clear {
+  flex: 0 0 auto;
+  margin-left: auto;
+  align-items: flex-end;
+  justify-content: flex-end;
+  display: flex;
+}
+
+.brc-filter-clear-all {
+  background: transparent;
+  background-color: transparent;
+  background-image: none;
+  border: none;
+  color: #6b7280;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  text-transform: none;
+  text-shadow: none;
+  letter-spacing: normal;
+  cursor: pointer;
+  padding: 6px 0;
+  margin: 0;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  box-shadow: none;
+  filter: none;
+}
+
+.brc-filter-clear-all:hover {
+  color: #1a1a18;
+  background: transparent;
+  background-color: transparent;
+}
+
+.brc-filter-clear-all[hidden] {
+  display: none;
 }
 
 .brc-pl-search-hint {
@@ -1440,8 +1496,10 @@ table.tblConsole #tbData td:nth-child(2) {
   color: #1a1a18;
 }
 
-/* Custom checkbox styling for the videos table (BCON-141, Frame C) */
-#tblMainList input[type="checkbox"] {
+/* Custom checkbox styling — videos table (Frame C) and the
+   filter panel "Show only clips" toggle (Frame B). Same look. */
+#tblMainList input[type="checkbox"],
+.brc-filter-checkbox input[type="checkbox"] {
   -webkit-appearance: none;
   appearance: none;
   width: 15px;
@@ -1456,12 +1514,14 @@ table.tblConsole #tbData td:nth-child(2) {
   padding: 0;
 }
 
-#tblMainList input[type="checkbox"]:checked {
+#tblMainList input[type="checkbox"]:checked,
+.brc-filter-checkbox input[type="checkbox"]:checked {
   background: #1a1a18;
   border-color: #1a1a18;
 }
 
-#tblMainList input[type="checkbox"]:checked::after {
+#tblMainList input[type="checkbox"]:checked::after,
+.brc-filter-checkbox input[type="checkbox"]:checked::after {
   content: '';
   display: block;
   position: absolute;

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -558,6 +558,44 @@ body {
   font-family: inherit;
 }
 
+/* Scoped table spinner (tab-switch loading) */
+.brc-table-wrapper {
+  position: relative;
+}
+
+.brc-table-spinner {
+  position: absolute;
+  top: 44px; /* below the sticky-style table header */
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 60px;
+  background: rgba(255, 255, 255, 0.85);
+  z-index: 5;
+  pointer-events: none;
+}
+
+.brc-table-spinner[hidden] {
+  display: none;
+}
+
+.brc-spinner {
+  display: inline-block;
+  width: 28px;
+  height: 28px;
+  border: 3px solid rgba(26, 26, 24, 0.15);
+  border-top-color: #1a1a18;
+  border-radius: 50%;
+  animation: brc-spin 0.8s linear infinite;
+}
+
+@keyframes brc-spin {
+  to { transform: rotate(360deg); }
+}
+
 a.home {
   cursor: pointer;
   display: block;

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -392,6 +392,88 @@ betty-titlebar {
   border-color: #d6d4cc;
 }
 
+/* Bulk action bar (BCON-141, Frame C) */
+.brc-bulk-bar {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  margin-left: 6px;
+}
+
+.brc-bulk-bar[hidden] {
+  display: none;
+}
+
+.brc-bulk-bar-divider {
+  display: inline-block;
+  width: 1px;
+  height: 20px;
+  background: #e8e6df;
+  margin: 0 4px;
+}
+
+.brc-bulk-bar-count {
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 400;
+  color: #1a1a18;
+}
+
+.brc-bulk-bar-btn {
+  display: inline-flex;
+  align-items: center;
+  height: 34px;
+  padding: 0 16px;
+  background: #fff;
+  background-image: none;
+  background-color: #fff;
+  border: 1px solid #e8e6df;
+  border-radius: 8px;
+  color: #1a1a18;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  text-transform: none;
+  text-shadow: none;
+  letter-spacing: normal;
+  cursor: pointer;
+  box-shadow: none;
+  filter: none;
+  margin: 0;
+  line-height: 32px;
+}
+
+.brc-bulk-bar-btn:hover {
+  background: #f7f6f2;
+  background-color: #f7f6f2;
+  color: #1a1a18;
+}
+
+.brc-bulk-bar-clear {
+  background: transparent;
+  background-image: none;
+  background-color: transparent;
+  border: none;
+  color: #6b7280;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 400;
+  text-transform: none;
+  text-shadow: none;
+  letter-spacing: normal;
+  cursor: pointer;
+  box-shadow: none;
+  filter: none;
+  padding: 0 4px;
+  margin: 0;
+}
+
+.brc-bulk-bar-clear:hover {
+  color: #1a1a18;
+  background: transparent;
+  background-color: transparent;
+}
+
 /* Pill search */
 .brc-pill-search {
   display: inline-flex;
@@ -600,6 +682,30 @@ betty-titlebar {
 
 @keyframes brc-spin {
   to { transform: rotate(360deg); }
+}
+
+/* Empty-state message (BCON-141) */
+.brc-empty-state {
+  padding: 60px 20px;
+  text-align: center;
+  font-family: 'Inter', adobe-clean, Helvetica, Arial, sans-serif;
+}
+
+.brc-empty-state[hidden] {
+  display: none;
+}
+
+.brc-empty-state-title {
+  font-size: 15px;
+  font-weight: 500;
+  color: #1a1a18;
+  margin: 0 0 6px;
+}
+
+.brc-empty-state-hint {
+  font-size: 13px;
+  color: #6b7280;
+  margin: 0;
 }
 
 a.home {
@@ -1328,9 +1434,44 @@ table.tblConsole #tbData td:nth-child(2) {
   color: #1a1a18;
 }
 
-#tbData tr.select {
+#tbData tr.select,
+#tbData tr.is-selected {
   background-color: #f0efea;
   color: #1a1a18;
+}
+
+/* Custom checkbox styling for the videos table (BCON-141, Frame C) */
+#tblMainList input[type="checkbox"] {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 15px;
+  height: 15px;
+  border: 1.5px solid #c8c7c2;
+  border-radius: 3px;
+  background: #fff;
+  cursor: pointer;
+  vertical-align: middle;
+  margin: 0;
+  position: relative;
+  padding: 0;
+}
+
+#tblMainList input[type="checkbox"]:checked {
+  background: #1a1a18;
+  border-color: #1a1a18;
+}
+
+#tblMainList input[type="checkbox"]:checked::after {
+  content: '';
+  display: block;
+  position: absolute;
+  left: 3px;
+  top: 0;
+  width: 4px;
+  height: 8px;
+  border-right: 1.5px solid #fff;
+  border-bottom: 1.5px solid #fff;
+  transform: rotate(45deg);
 }
 
 #playerDiv.overlay.ui-draggable {

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -1478,6 +1478,19 @@ table.tblConsole #tbData td:nth-child(2) {
   font-weight: 500;
 }
 
+/* Playlist rows wrap the name in an <a class="edit-playlist"> for click
+   handling — without this, browsers paint it as a hyperlink-blue underlined
+   link. Inherit the row color so playlist rows match the plain-text
+   styling of the video rows. */
+#tbData a {
+  color: inherit;
+  text-decoration: none;
+}
+
+#tbData a:hover {
+  text-decoration: none;
+}
+
 /* Existing oddLine / evenLine zebra-stripe rules conflict with the
    new flat table — neutralise both back to white. */
 #tbData tr.oddLine,

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -18,6 +18,12 @@ body {
   z-index:999999;
 }
 
+/* AEM injects a <betty-titlebar> above tool-page content; hide it so our
+   own .brc-header is the only top-of-page chrome. */
+betty-titlebar {
+  display: none !important;
+}
+
 /* ---- BCON-121: Header revamp ---- */
 .brc-header {
   position: relative;

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -581,10 +581,6 @@ table.tblConsole {
   border-style: none;
 }
 
-tr.trCenterHeader {
-  background-color: #fff;
-}
-
 #tblMainList {
   overflow: auto;
   table-layout: auto;
@@ -1149,19 +1145,11 @@ div.hLine {
 
 
 tr.trCenterHeader {
-  background-color: #C3DDF6;
+  background-color: #fff;
 }
 
-#headTitle {
-  padding: 10px 10px 0 10px;
-  text-transform: uppercase;
-}
-
-#divVideoCount {
-  padding: 0 10px 10px 10px;
-  font-size: 12px;
-  text-transform: uppercase;
-}
+/* #headTitle and #divVideoCount styling lives on .brc-list-title and
+   .brc-count-badge; keep these id selectors out of the way. */
 
 td.tdMetadata, th#trHeader {
   padding: 0 20px;
@@ -1237,24 +1225,68 @@ tr.hover {
 }
 
 #trHeader .tdMainTableHead {
-  background-color: #080886;
-  color: #fff;
-  padding: 5px;
+  background-color: #fff;
+  color: #1a1a18;
+  font-family: 'Inter', adobe-clean, Helvetica, Arial, sans-serif;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 0 12px;
+  height: 44px;
   border: 0;
-  border-bottom: 1px solid #fff;
+  border-top: 1px solid #e8e6df;
+  border-bottom: 1px solid #e8e6df;
+  text-transform: none;
+  text-align: left;
+  white-space: nowrap;
+}
+
+#trHeader .tdMainTableHead#checkCol {
+  width: 36px;
+  padding: 0 12px;
 }
 
 table.tblConsole {
   background-color: #fff;
-  color: #3b3b3b;
+  color: #1a1a18;
   font-size: 13px;
   width: 100%;
   border-style: none;
 }
 
+table.tblConsole #tbData tr {
+  height: 52px;
+}
+
 table.tblConsole #tbData td {
-  border-bottom: 1px solid #eee;
-  line-height: 1.8;
+  border-bottom: 1px solid #f0efea;
+  padding: 0 12px;
+  font-family: 'Inter', adobe-clean, Helvetica, Arial, sans-serif;
+  font-size: 13px;
+  font-weight: 400;
+  color: #1a1a18;
+  line-height: 1.4;
+  vertical-align: middle;
+}
+
+table.tblConsole #tbData td:nth-child(2) {
+  font-weight: 500;
+}
+
+/* Existing oddLine / evenLine zebra-stripe rules conflict with the
+   new flat table — neutralise both back to white. */
+#tbData tr.oddLine,
+#tbData tr.evenLine {
+  background-color: #fff;
+}
+
+#tbData tr.hover {
+  background-color: #f7f6f2;
+  color: #1a1a18;
+}
+
+#tbData tr.select {
+  background-color: #f0efea;
+  color: #1a1a18;
 }
 
 #playerDiv.overlay.ui-draggable {
@@ -1319,20 +1351,22 @@ div.delConfPop {
   width: 600px;
 }
 
-th.sortable.ASC span.order {
-  background: url("../img/asc.png") right center no-repeat;
-  padding-right: 20px;
+th.sortable {
+  cursor: pointer;
 }
 
-th.sortable.DESC span.order {
-  background: url("../img/desc.png") right center no-repeat;
-  padding-right: 20px;
+th.sortable .order::after {
+  display: inline-block;
+  margin-left: 6px;
+  font-size: 11px;
+  font-weight: 400;
+  color: #c8c7c2;
+  vertical-align: middle;
 }
 
-th.sortable.NONE span.order {
-  background: url("../img/none.png") right center no-repeat;
-  padding-right: 20px;
-}
+th.sortable.ASC .order::after  { content: '↑'; color: #6b7280; }
+th.sortable.DESC .order::after { content: '↓'; color: #6b7280; }
+th.sortable.NONE .order::after { content: '↕'; color: #c8c7c2; }
 
 img.optionsIcon {
   width: 28px;

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -2147,42 +2147,61 @@ body {
   position: relative;
 }
 
-.butDiv > span > div.menu {
+/* Folder-picker dropdown — used by both the legacy .butDiv (playlist
+   drill-down view) and the new bulk action bar (videos view). The
+   selectors used to be scoped to .butDiv, which broke the bulk version
+   when .butDiv was hidden — drop that scope. */
+.folder-selector.menu {
   display: none;
   position: absolute;
   left: 0;
   box-shadow: rgba(0, 0, 0, 0.1) 0px 1px 3px 0px, rgba(0, 0, 0, 0.06) 0px 1px 2px 0px;
   min-width: 200px;
+  background: #fff;
+  border: 1px solid #e8e6df;
+  border-radius: 8px;
+  z-index: 100;
 }
 
-.butDiv > span > div.menu.open {
+.folder-selector.menu.open {
   display: block;
 }
 
-.butDiv > span > div.menu .menu-options {
+.folder-selector .menu-options {
   list-style: none;
   padding: 0.5rem 0;
   margin: 0;
 }
 
-.butDiv > span > div.menu .menu-options .menu-option {
+.folder-selector .menu-options .menu-option {
   padding: 0.5rem 1rem 0.5rem 2.25rem;
   background: transparent url(/apps/brightcove/clientlibs/clientlib-tools/img/shared/img/folder.svg) 0.5rem no-repeat;
 }
 
-.butDiv > span > div.menu .menu-options .menu-option.remove {
+.folder-selector .menu-options .menu-option.remove {
   padding: 0.5rem 1rem 0.5rem 2.25rem;
   background: transparent url(/apps/brightcove/clientlibs/clientlib-tools/img/shared/img/folder-delete.svg) 0.5rem no-repeat;
 }
 
-.butDiv > span > div.menu .menu-options .menu-option:hover {
+.folder-selector .menu-options .menu-option:hover {
   background: rgba(0, 0, 0, 0.1) url(/apps/brightcove/clientlibs/clientlib-tools/img/shared/img/folder-open.svg) 0.5rem no-repeat;
   cursor: pointer;
 }
 
-.butDiv > span > div.menu .menu-options .menu-option.remove:hover {
+.folder-selector .menu-options .menu-option.remove:hover {
   background: rgba(0, 0, 0, 0.1) url(/apps/brightcove/clientlibs/clientlib-tools/img/shared/img/folder-delete.svg) 0.5rem no-repeat;
   cursor: pointer;
+}
+
+/* Position the bulk-bar dropdown directly under the trigger button. */
+.brc-bulk-move-wrapper {
+  position: relative;
+  display: inline-flex;
+}
+
+.brc-bulk-move-wrapper > .folder-selector.menu {
+  top: 100%;
+  margin-top: 4px;
 }
 
 #tbData span.playlist-actions {

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -311,6 +311,253 @@ body {
   font-weight: 600;
 }
 
+/* ---- Title row + pill search + filter panel (Frames A/B) ---- */
+.brc-title-row {
+  display: flex;
+  align-items: center;
+  padding: 18px 0 10px;
+  font-family: 'Inter', adobe-clean, Helvetica, Arial, sans-serif;
+}
+
+.brc-title-row-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.brc-title-row-right {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+}
+
+.brc-list-title {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 700;
+  color: #1a1a18;
+  text-transform: none;
+  padding: 0;
+  white-space: nowrap;
+}
+
+.brc-count-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  height: 22px;
+  padding: 0 6px;
+  background: #f0efea;
+  border-radius: 99px;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 400;
+  color: #1a1a18;
+  line-height: 1;
+}
+
+.brc-count-badge:empty {
+  display: none;
+}
+
+.brc-filter-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  background: #fff;
+  border: 1px solid #e8e6df;
+  border-radius: 8px;
+  color: #1a1a18;
+  cursor: pointer;
+  margin-left: 10px;
+}
+
+.brc-filter-btn:hover {
+  background: #f7f6f2;
+}
+
+.brc-filter-btn[aria-expanded="true"] {
+  background: #f0efea;
+  border-color: #d6d4cc;
+}
+
+/* Pill search */
+.brc-pill-search {
+  display: inline-flex;
+  align-items: center;
+  height: 38px;
+  background: #fff;
+  border: 1px solid #e8e6df;
+  border-radius: 99px;
+  padding: 0 6px 0 14px;
+  font-family: inherit;
+  font-size: 13px;
+  color: #1a1a18;
+  min-width: 280px;
+}
+
+.brc-pill-search-icon {
+  display: inline-flex;
+  align-items: center;
+  color: #6b7280;
+  margin-right: 8px;
+  flex-shrink: 0;
+}
+
+.brc-pill-search-input {
+  border: none;
+  background: transparent;
+  outline: none;
+  font-family: inherit;
+  font-size: 13px;
+  color: #1a1a18;
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 0;
+  height: 100%;
+}
+
+.brc-pill-search-input::placeholder {
+  color: #9ca3af;
+}
+
+.brc-pill-search-input:focus {
+  outline: none;
+}
+
+.brc-pill-search-clear {
+  background: transparent;
+  border: none;
+  color: #6b7280;
+  font-size: 14px;
+  cursor: pointer;
+  padding: 0 6px;
+  line-height: 1;
+}
+
+.brc-pill-search-clear:hover {
+  color: #1a1a18;
+}
+
+.brc-pill-search-field {
+  height: 28px;
+  border: none;
+  background: transparent;
+  font-family: inherit;
+  font-size: 12px;
+  color: #6b7280;
+  padding: 0 4px;
+  margin-left: 4px;
+  cursor: pointer;
+  border-left: 1px solid #e8e6df;
+}
+
+#searchBut.brc-pill-search-go,
+#searchBut_pl.brc-pill-search-go {
+  height: 28px;
+  margin: 0 0 0 6px;
+  padding: 0 12px;
+  background: #1a1a18;
+  background-image: none;
+  background-color: #1a1a18;
+  border: none;
+  border-radius: 99px;
+  color: #fff;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  text-transform: none;
+  text-shadow: none;
+  letter-spacing: normal;
+  cursor: pointer;
+  box-shadow: none;
+  filter: none;
+  line-height: 28px;
+}
+
+#searchBut.brc-pill-search-go:hover,
+#searchBut_pl.brc-pill-search-go:hover {
+  background: #2a2a26;
+  background-color: #2a2a26;
+  color: #fff;
+}
+
+/* Filter panel */
+.brc-filter-panel {
+  display: flex;
+  align-items: stretch;
+  gap: 40px;
+  background: #fff;
+  border: 1px solid #e8e6df;
+  border-radius: 10px;
+  padding: 13px 19px;
+  margin-bottom: 10px;
+  font-family: inherit;
+}
+
+.brc-filter-panel[hidden] {
+  display: none;
+}
+
+.brc-filter-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 200px;
+}
+
+.brc-filter-section:nth-child(2) {
+  flex: 1;
+  min-width: 300px;
+}
+
+.brc-filter-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.77px;
+  text-transform: uppercase;
+  color: #1a1a18;
+}
+
+.brc-filter-select {
+  height: 38px;
+  padding: 0 13px;
+  border: 1px solid #e8e6df;
+  border-radius: 8px;
+  background: #fff;
+  font-family: inherit;
+  font-size: 13px;
+  color: #1a1a18;
+}
+
+.brc-filter-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: #1a1a18;
+  margin-top: 8px;
+  cursor: pointer;
+}
+
+.brc-filter-checkbox input[type="checkbox"] {
+  width: 15px;
+  height: 15px;
+  margin: 0;
+}
+
+.brc-pl-search-hint {
+  font-size: 11px;
+  color: #6b7280;
+  margin: -4px 0 8px;
+  font-family: inherit;
+}
+
 a.home {
   cursor: pointer;
   display: block;

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -155,6 +155,11 @@ betty-titlebar {
   font-family: inherit;
 }
 
+.brc-account-trigger[aria-expanded="true"] {
+  background: #f7f6f2;
+  border-color: #d6d4cc;
+}
+
 .brc-account-info {
   display: flex;
   flex-direction: column;
@@ -504,6 +509,12 @@ betty-titlebar {
   font-size: 13px;
   color: #1a1a18;
   min-width: 280px;
+}
+
+/* Frame C: when the bulk action bar is visible, the pill search shrinks to
+   220px so both surfaces sit comfortably side-by-side. */
+.brc-title-row:has(#bulkActionBar:not([hidden])) .brc-pill-search {
+  min-width: 220px;
 }
 
 .brc-pill-search-icon {

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -89,6 +89,21 @@ $(function () {
         window.location.reload();
     });
 
+    $('.brc-tab').on('click', function () {
+        var $tab = $(this);
+        if ($tab.hasClass('is-active')) return;
+
+        searchVal = '';
+        $('.brc-tab').removeClass('is-active').attr('aria-selected', 'false');
+        $tab.addClass('is-active').attr('aria-selected', 'true');
+
+        if ($tab.attr('id') === 'allVideos') {
+            Load(getAllVideosURL());
+        } else if ($tab.attr('id') === 'allPlaylists') {
+            Load(getAllPlaylistsURL());
+        }
+    });
+
     $('.butDiv').hide();
 
     $('body').on('click', function(event) {

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -166,6 +166,18 @@ $(function () {
         }
     });
 
+    // Filter panel toggle
+    $('#filterToggle').on('click', function () {
+        var $panel = $('#filterPanel');
+        var willOpen = $panel.is('[hidden]');
+        if (willOpen) {
+            $panel.removeAttr('hidden');
+        } else {
+            $panel.attr('hidden', '');
+        }
+        $(this).attr('aria-expanded', willOpen ? 'true' : 'false');
+    });
+
     $('.brc-account-row').on('click', function () {
         var $row = $(this);
         if ($row.hasClass('is-active')) {

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -860,8 +860,8 @@ function buildMainVideoList(title) {
         $("#nameCol").addClass("ASC").attr("data-sortType", "");
     }
     // Display video count
-    document.getElementById('divVideoCount').innerHTML = oCurrentVideoList.length + " videos";
-    document.getElementById('nameCol').innerHTML = "Video Name<span class='order'></span>";
+    document.getElementById('divVideoCount').innerHTML = oCurrentVideoList.length;
+    document.getElementById('nameCol').innerHTML = "Name<span class='order'></span>";
     document.getElementById('headTitle').innerHTML = title;
     document.getElementById('search').value = searchVal ? searchVal : "Search Videos";
     $('#searchClear').toggle(!!searchVal && searchVal !== 'Search Videos');
@@ -925,8 +925,8 @@ function buildPlaylistList() {
     $("#trHeader th.sortable").removeClass("NONE").removeClass("ASC").removeClass("DESC");
 
     // Display Playlist count
-    document.getElementById('divVideoCount').innerHTML = oCurrentPlaylistList.length + " playlists";
-    document.getElementById('nameCol').innerHTML = "Playlist Name";
+    document.getElementById('divVideoCount').innerHTML = oCurrentPlaylistList.length;
+    document.getElementById('nameCol').innerHTML = "Name";
     document.getElementById('headTitle').innerHTML = "All Playlists";
     document.getElementById('search_pl').value = searchVal ? searchVal : "Search Playlists";
     $('#searchClear_pl').toggle(!!searchVal && searchVal !== 'Search Playlists');

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -57,6 +57,24 @@ function hideTableSpinner() {
     $('#tableSpinner').attr('hidden', '');
 }
 
+// BCON-142: visual indicator + clear-all for the filter panel.
+function isAnyFilterActive() {
+    var l = $('#label_list').val();
+    var f = $('#fldr_list').val();
+    var c = $('#filter_clips').is(':checked');
+    return (l && l !== 'all') || (f && f !== 'all') || c;
+}
+
+function updateFilterIndicator() {
+    var active = isAnyFilterActive();
+    $('#filterToggle').toggleClass('has-active-filters', active);
+    if (active) {
+        $('#filterClearAll').removeAttr('hidden');
+    } else {
+        $('#filterClearAll').attr('hidden', '');
+    }
+}
+
 function brcToast(message) {
     var existing = document.getElementById('brcToast');
     if (existing) existing.parentNode.removeChild(existing);
@@ -229,6 +247,25 @@ $(function () {
             // display all
             $('#tbData tr').show();
         }
+        // Surface the empty state if the clips filter hides everything.
+        var visibleRows = $('#tbData tr:visible').length;
+        if (visibleRows === 0 && event.currentTarget.checked) {
+            $('#emptyStateTitle').text('No clips in this list');
+            $('#emptyStateHint').text('Uncheck "Show only clips" to see all videos.');
+            $('#emptyState').removeAttr('hidden');
+        } else {
+            $('#emptyState').attr('hidden', '');
+        }
+        updateFilterIndicator();
+    });
+
+    $('#filterClearAll').on('click', function () {
+        $('#label_list').val('all');
+        $('#fldr_list').val('all');
+        $('#filter_clips').prop('checked', false);
+        $('#tbData tr').show();
+        updateFilterIndicator();
+        Load(getAllVideosURL());
     });
 
     $('#tbData').on('click', '.edit-playlist', function(event) {
@@ -623,6 +660,7 @@ function loadFolders() {
             console.log('search videos by folder=' + selected);
             Load(getFolderListingUrl(selected));
         }
+        updateFilterIndicator();
     });
 
     // now make the API call to load the folder options
@@ -708,6 +746,7 @@ function loadLabels() {
             console.log('search videos by label=' + selected);
             Load(getLabelListingUrl(selected));
         }
+        updateFilterIndicator();
     });
 
     // now make the API call to load the folder options

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -1980,18 +1980,14 @@ function loadStart()
 function loadEnd()
 {
     $('html,body').scrollTop(0);
-    $("#syncdbutton").css("color", "#333333");
-    $("#syncdbutton").html('SYNC DATABASE');
-    $("#syncdbutton").prop('disabled', false);
     $("#loading").slideUp("fast");
     $(".loading").hide();
 }
 
 function syncStart()
 {
-    $("#syncdbutton").css("color", "#6D8CAE");
-    $("#syncdbutton").html('LOADING SYNC');
-    $("#syncdbutton").prop('disabled', true);
+    $("#syncdbutton").addClass('is-loading').prop('disabled', true);
+    $("#syncdbutton .brc-sync-btn-label").text('Loading sync');
     $("#loading").slideDown("fast");
     $(".loading").show();
 
@@ -2002,6 +1998,8 @@ function syncStart()
 
 function syncEnd() {
     $(".syncingMsg").fadeOut();
+    $("#syncdbutton").removeClass('is-loading').prop('disabled', false);
+    $("#syncdbutton .brc-sync-btn-label").text('Sync database');
     loadEnd();
     $(".loadingMsg").hide();
     $(".loading").hide();

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -49,6 +49,14 @@ $( document ).ready(function() {
     } catch (e) { /* sessionStorage unavailable — toast skipped */ }
 });
 
+function showTableSpinner() {
+    $('#tableSpinner').removeAttr('hidden');
+}
+
+function hideTableSpinner() {
+    $('#tableSpinner').attr('hidden', '');
+}
+
 function brcToast(message) {
     var existing = document.getElementById('brcToast');
     if (existing) existing.parentNode.removeChild(existing);
@@ -122,6 +130,8 @@ $(function () {
         searchVal = '';
         $('.brc-tab').removeClass('is-active').attr('aria-selected', 'false');
         $tab.addClass('is-active').attr('aria-selected', 'true');
+
+        showTableSpinner();
 
         if ($tab.attr('id') === 'allVideos') {
             Load(getAllVideosURL());
@@ -916,6 +926,7 @@ function buildMainVideoList(title) {
     else {
         closeBox("tdMeta");
     }
+    hideTableSpinner();
 }
 
 function buildPlaylistList() {
@@ -968,6 +979,7 @@ function buildPlaylistList() {
         $(this).removeClass("hover");
     });
 
+    hideTableSpinner();
 }
 function getPlaylist(idx) {
     oCurrentPlaylistList = oCurrentPlaylistList[idx];

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -143,11 +143,22 @@ $(function () {
 
     $('.brc-tab').on('click', function () {
         var $tab = $(this);
-        if ($tab.hasClass('is-active')) return;
+        // No early-return on already-active: programmatic `.click()` callers
+        // (e.g. createPlaylistSubmit() jumping back to the playlist list after
+        // creation) need the Load() to fire even if the tab is visually active.
 
         searchVal = '';
         $('.brc-tab').removeClass('is-active').attr('aria-selected', 'false');
         $tab.addClass('is-active').attr('aria-selected', 'true');
+
+        // Reset the video-side filter UI when switching tabs so the
+        // active-filter dot doesn't lie about the unfiltered list we're
+        // about to load.
+        $('#label_list').val('all');
+        $('#fldr_list').val('all');
+        $('#filter_clips').prop('checked', false);
+        updateFilterIndicator();
+        $('#emptyState').attr('hidden', '');
 
         showTableSpinner();
 
@@ -264,6 +275,9 @@ $(function () {
         $('#fldr_list').val('all');
         $('#filter_clips').prop('checked', false);
         $('#tbData tr').show();
+        // Hide the clips-empty-state immediately so it doesn't linger
+        // alongside the now-visible rows while Load() is in flight.
+        $('#emptyState').attr('hidden', '');
         updateFilterIndicator();
         Load(getAllVideosURL());
     });
@@ -427,17 +441,19 @@ $(function () {
     })
 
     $('body').on('brc:checked', function(event) {
-        var inputTags = document.getElementById('listTable').getElementsByTagName('input');
+        // Scope to row checkboxes only — the legacy `getElementsByTagName('input')`
+        // walk picked up #search/#search_pl/#filter_clips after the BCON-121
+        // restructure put the filter panel inside #listTable, inflating selection
+        // counts and quietly toggling the clips filter on select-all.
         paging.selectedVideos = [];
-        var l = inputTags.length
-        for (var i = 2; i < l; i++) {
-            if (true == inputTags[i].checked) {
-                paging.selectedVideos.push(inputTags[i]);
-                $(inputTags[i]).closest('tr').addClass('is-selected');
+        $('#tbData input[type="checkbox"]').each(function () {
+            if (this.checked) {
+                paging.selectedVideos.push(this);
+                $(this).closest('tr').addClass('is-selected');
             } else {
-                $(inputTags[i]).closest('tr').removeClass('is-selected');
+                $(this).closest('tr').removeClass('is-selected');
             }
-        }
+        });
         var n = paging.selectedVideos.length;
         $('#bulkCount').text(n);
         if (window.brcCurrentView === 'videos' && n > 0) {
@@ -2094,6 +2110,9 @@ function loadEnd()
     $('html,body').scrollTop(0);
     $("#loading").slideUp("fast");
     $(".loading").hide();
+    // Defensive: ensure the scoped tab spinner clears on error paths too,
+    // not only on buildMainVideoList / buildPlaylistList success.
+    hideTableSpinner();
 }
 
 function syncStart()
@@ -2120,28 +2139,30 @@ function syncEnd() {
 
 
 function createPlaylistBox() {
-    var inputTags = document.getElementById('listTable').getElementsByTagName('input'),
-        form = document.getElementById('createPlaylistForm'),
-        table = document.getElementById("createPlstVideoTable"),
-        idx = 1,
-        l = inputTags.length;
+    var form = document.getElementById('createPlaylistForm'),
+        idx = 1;
 
     form.playlist.value = '';
 
-    for (var i = 3; i < l; i++) {
-        if (inputTags[i].checked) {
-            $("#createPlstVideoTable").append(
-                '<tr ><td>' + oCurrentVideoList[i - 4].name +
-                '</td><td style="width: 25%;" >' + oCurrentVideoList[i - 4].id + '</td></tr>'
-            );
+    // Iterate row checkboxes directly. Each row checkbox's `id` attribute
+    // is the matching index in oCurrentVideoList (set by buildMainVideoList).
+    $('#tbData input[type="checkbox"]').each(function () {
+        if (!this.checked) return;
+        var videoIdx = parseInt(this.id, 10);
+        var v = oCurrentVideoList[videoIdx];
+        if (!v) return;
+        $("#createPlstVideoTable").append(
+            '<tr ><td>' + v.name +
+            '</td><td style="width: 25%;" >' + v.id + '</td></tr>'
+        );
 
-            if (1 != idx) {
-                form.playlist.value += ',';
-            }
-            form.playlist.value += oCurrentVideoList[i - 4].id;
-            idx++;
+        if (1 != idx) {
+            form.playlist.value += ',';
         }
-    }
+        form.playlist.value += v.id;
+        idx++;
+    });
+
     if (1 == idx) {
         alert("Please select at least one video to create a playlist.");
         return;
@@ -2247,25 +2268,12 @@ function changePage(num) {
 }
 
 function checkCheck() {
-    var count = 1;
-    var inputTags = document.getElementById('listTable').getElementsByTagName('input');
-    var checkedTags = [];
-    var selChek = document.getElementById('checkToggle');
-    var l = inputTags.length
-    for (var i = 2; i < l; i++) {
-        if (true == inputTags[i].checked) {
-            checkedTags.push(inputTags[i]);
-            count++;
-        } else if ((i - count) > 1) {//If one checkbox was skipped, then the total has to be < l, so uncheck selChek  and return.
-            selChek.checked = false;
-            return;
-        }
-    }
-    if (selChek.checked == true && count < l) {
-        selChek.checked = false;
-    } else if (false == selChek.checked && count >= l - 1) {
-        selChek.checked = true;
-    }
+    // Master #checkToggle reflects "are all row checkboxes checked?"
+    var $rows = $('#tbData input[type="checkbox"]');
+    var total = $rows.length;
+    var checked = $rows.filter(':checked').length;
+    document.getElementById('checkToggle').checked = (total > 0 && checked === total);
+    $('body').trigger('brc:checked');
 }
 
 function toggleSelect(check) {
@@ -2278,19 +2286,11 @@ function toggleSelect(check) {
 }
 
 function checkAll() {
-    var inputTags = document.getElementById('listTable').getElementsByTagName('input');
-    var l = inputTags.length;
-    for (var i = 2; i < l; i++) {
-        inputTags[i].checked = true;
-    }
+    $('#tbData input[type="checkbox"]').prop('checked', true);
 }
 
 function checkNone() {
-    var inputTags = document.getElementById('listTable').getElementsByTagName('input');
-    var l = inputTags.length;
-    for (var i = 2; i < l; i++) {
-        inputTags[i].checked = false;
-    }
+    $('#tbData input[type="checkbox"]').prop('checked', false);
 }
 
 //for example write functions are disabled, so display this message:

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -1012,6 +1012,15 @@ function buildMainVideoList(title) {
         $('#emptyStateHint').text(hasFilter ? 'Try clearing the search or adjusting your filters.' : 'Sync the database or add videos in Brightcove.');
         $('#emptyState').removeAttr('hidden');
     }
+
+    // Re-apply the DOM-only clips filter if the checkbox is still active —
+    // any folder/label change rebuilds rows fresh and would otherwise show
+    // all videos despite the clips-only indicator still being on.
+    if ($('#filter_clips').is(':checked')) {
+        $('#tbData tr').hide();
+        $('#tbData tr.state-clip').show();
+    }
+
     hideTableSpinner();
 }
 

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -38,7 +38,33 @@ $( document ).ready(function() {
     {
         CQ.Ext.util.Cookies.set('brc_act', $("#selAccount").val());
     }
+
+    // If we just reloaded after switching accounts, surface a toast.
+    try {
+        var switchedAlias = window.sessionStorage && sessionStorage.getItem('brc_account_switched');
+        if (switchedAlias) {
+            sessionStorage.removeItem('brc_account_switched');
+            brcToast('Switched to ' + switchedAlias);
+        }
+    } catch (e) { /* sessionStorage unavailable — toast skipped */ }
 });
+
+function brcToast(message) {
+    var existing = document.getElementById('brcToast');
+    if (existing) existing.parentNode.removeChild(existing);
+    var $toast = $('<div class="brc-toast" id="brcToast" role="status" aria-live="polite">'
+        + '<span class="brc-toast-icon" aria-hidden="true">✓</span>'
+        + '<span class="brc-toast-msg"></span></div>');
+    $toast.find('.brc-toast-msg').text(message);
+    $('body').append($toast);
+    // Force reflow so the entry transition runs.
+    void $toast[0].offsetHeight;
+    $toast.addClass('is-visible');
+    setTimeout(function () {
+        $toast.removeClass('is-visible');
+        setTimeout(function () { $toast.remove(); }, 250);
+    }, 3000);
+}
 
 
 
@@ -148,9 +174,15 @@ $(function () {
             return;
         }
         var accountId = $row.attr('data-account-id');
+        var accountAlias = $row.attr('data-account-alias') || accountId;
         if (CQ && CQ.Ext) {
             CQ.Ext.util.Cookies.set('brc_act', accountId);
         }
+        try {
+            if (window.sessionStorage) {
+                sessionStorage.setItem('brc_account_switched', accountAlias);
+            }
+        } catch (e) { /* sessionStorage unavailable — toast won't appear, switch still happens */ }
         window.location.reload();
     });
 

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -641,7 +641,7 @@ function suggestVideosForPlaylist(data) {
 }
 
 function moveVideoToFolder() {
-    $('.folder-selector').toggleClass('open');
+    $('#bulkActionBar .folder-selector').toggleClass('open');
 }
 
 function getMoveVideoToFolderUrl(video_id, folder_id) {
@@ -948,6 +948,7 @@ function buildMainVideoList(title) {
     paging.selectedVideos = [];
     $('#bulkActionBar').attr('hidden', '');
     $('#bulkCount').text(0);
+    $('#checkToggle').prop('checked', false);
 
     //Wipe out the old results
     $("#tbData").empty();

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -1450,6 +1450,13 @@ function syncDB()
         {
             syncEnd();
             data = $.parseJSON(data);
+        },
+        error: function () {
+            // Without this, a failed sync leaves #syncdbutton stuck in
+            // .is-loading + disabled forever (the old loadEnd() reset
+            // the button as a side effect; that side effect was removed
+            // when loadEnd stopped clobbering the new SVG/label markup).
+            syncEnd();
         }
     });
 }

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -104,6 +104,56 @@ $(function () {
         }
     });
 
+    // Account switcher popover
+    $('#accountTrigger').on('click', function (e) {
+        e.stopPropagation();
+        var $popover = $('#accountPopover');
+        var willOpen = $popover.is('[hidden]');
+        if (willOpen) {
+            $popover.removeAttr('hidden');
+        } else {
+            $popover.attr('hidden', '');
+        }
+        $(this).attr('aria-expanded', willOpen ? 'true' : 'false');
+    });
+
+    $('#accountTrigger').on('keydown', function (e) {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            $(this).trigger('click');
+        }
+    });
+
+    $(document).on('click', function (e) {
+        var $popover = $('#accountPopover');
+        if ($popover.is('[hidden]')) return;
+        if (!$(e.target).closest('#accountPopover, #accountTrigger').length) {
+            $popover.attr('hidden', '');
+            $('#accountTrigger').attr('aria-expanded', 'false');
+        }
+    });
+
+    $(document).on('keydown', function (e) {
+        if (e.key === 'Escape' && !$('#accountPopover').is('[hidden]')) {
+            $('#accountPopover').attr('hidden', '');
+            $('#accountTrigger').attr('aria-expanded', 'false').focus();
+        }
+    });
+
+    $('.brc-account-row').on('click', function () {
+        var $row = $(this);
+        if ($row.hasClass('is-active')) {
+            $('#accountPopover').attr('hidden', '');
+            $('#accountTrigger').attr('aria-expanded', 'false');
+            return;
+        }
+        var accountId = $row.attr('data-account-id');
+        if (CQ && CQ.Ext) {
+            CQ.Ext.util.Cookies.set('brc_act', accountId);
+        }
+        window.location.reload();
+    });
+
     $('.butDiv').hide();
 
     $('body').on('click', function(event) {

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -226,8 +226,14 @@ $(function () {
         }
         var accountId = $row.attr('data-account-id');
         var accountAlias = $row.attr('data-account-alias') || accountId;
+        // Set the brc_act cookie via CQ.Ext if available, otherwise fall
+        // back to document.cookie. Without this fallback the page would
+        // reload without the new cookie, leaving the user on the old
+        // account but showing a misleading "Switched to <alias>" toast.
         if (CQ && CQ.Ext) {
             CQ.Ext.util.Cookies.set('brc_act', accountId);
+        } else {
+            document.cookie = 'brc_act=' + encodeURIComponent(accountId) + '; path=/';
         }
         try {
             if (window.sessionStorage) {
@@ -1180,9 +1186,13 @@ function showPlaylist() {
 
     if (oCurrentVideoList.length > 0) {
         showMetaData(0);
+        $('#emptyState').attr('hidden', '');
     }
     else {
         closeBox("tdMeta");
+        $('#emptyStateTitle').text('No videos in this playlist');
+        $('#emptyStateHint').text('Add videos to this playlist in Brightcove to see them here.');
+        $('#emptyState').removeAttr('hidden');
     }
 
 }

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -876,8 +876,9 @@ function buildMainVideoList(title) {
     document.getElementById('search').value = searchVal ? searchVal : "Search Videos";
     $('#searchClear').toggle(!!searchVal && searchVal !== 'Search Videos');
     document.getElementById('tdMeta').style.display = "none";
-    document.getElementById('searchDiv').style.display = "inline";
+    document.getElementById('searchDiv').style.display = "inline-flex";
     document.getElementById('searchDiv_pl').style.display = "none";
+    $('#filterToggle').show();
 
     document.getElementById('checkToggle').style.display = "inline";
     $("span[name=buttonRow]").show();
@@ -943,8 +944,12 @@ function buildPlaylistList() {
     $('#searchClear_pl').toggle(!!searchVal && searchVal !== 'Search Playlists');
     document.getElementById('tdMeta').style.display = "none";
     document.getElementById('searchDiv').style.display = "none";
-    document.getElementById('searchDiv_pl').style.display = "inline";
+    document.getElementById('searchDiv_pl').style.display = "inline-flex";
     togglePlSearchHint(document.getElementById('selField_pl').value);
+    // Filter panel (LABELS / FOLDER / CLIPS ONLY) is video-only.
+    $('#filterToggle').hide();
+    $('#filterPanel').attr('hidden', '');
+    $('#filterToggle').attr('aria-expanded', 'false');
     document.getElementById('checkToggle').style.display = "none";
 	document.getElementById('pagination').style.display = "none";
     $("span[name=buttonRow]").hide();

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -1019,6 +1019,11 @@ function buildMainVideoList(title) {
     if ($('#filter_clips').is(':checked')) {
         $('#tbData tr').hide();
         $('#tbData tr.state-clip').show();
+        if ($('#tbData tr:visible').length === 0 && oCurrentVideoList.length > 0) {
+            $('#emptyStateTitle').text('No clips in this list');
+            $('#emptyStateHint').text('Uncheck "Show only clips" to see all videos.');
+            $('#emptyState').removeAttr('hidden');
+        }
     }
 
     hideTableSpinner();

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -396,9 +396,29 @@ $(function () {
         for (var i = 2; i < l; i++) {
             if (true == inputTags[i].checked) {
                 paging.selectedVideos.push(inputTags[i]);
+                $(inputTags[i]).closest('tr').addClass('is-selected');
+            } else {
+                $(inputTags[i]).closest('tr').removeClass('is-selected');
             }
         }
-        $('.butDiv').toggle(paging.selectedVideos.length > 0);
+        var n = paging.selectedVideos.length;
+        $('#bulkCount').text(n);
+        if (window.brcCurrentView === 'videos' && n > 0) {
+            $('#bulkActionBar').removeAttr('hidden');
+        } else {
+            $('#bulkActionBar').attr('hidden', '');
+        }
+        // Original .butDiv kept for the playlist drill-down view (Remove From Playlist).
+        $('.butDiv').toggle(window.brcCurrentView === 'playlist' && n > 0);
+    });
+
+    $('#bulkCreatePlaylist').on('click', function () { createPlaylistBox(); });
+    $('#bulkMoveToFolder').on('click', function () { moveVideoToFolder(); });
+    $('#bulkClear').on('click', function () {
+        $('#tbData input[type="checkbox"]').prop('checked', false);
+        $('#checkToggle').prop('checked', false);
+        $('#tbData tr').removeClass('is-selected');
+        $('body').trigger('brc:checked');
     });
 
     $('body').on('click', '.variant', function(event) {
@@ -863,6 +883,11 @@ function sort(object) {
 }
 function buildMainVideoList(title) {
 
+    window.brcCurrentView = 'videos';
+    paging.selectedVideos = [];
+    $('#bulkActionBar').attr('hidden', '');
+    $('#bulkCount').text(0);
+
     //Wipe out the old results
     $("#tbData").empty();
     if (!$("#nameCol").hasClass("ASC") && !$("#nameCol").hasClass("DESC") && !$("#nameCol").hasClass("NONE")) {
@@ -898,7 +923,7 @@ function buildMainVideoList(title) {
             "</td><td>"
             + (modDate.getMonth() + 1) + "/" + modDate.getDate() + "/" + modDate.getFullYear() + "\
             </td><td>"
-            + ((n.reference_id) ? n.reference_id : '') +
+            + ((n.reference_id) ? n.reference_id : '—') +
             "</td><td>"
             + n.id +
             "</td></tr>"
@@ -923,14 +948,22 @@ function buildMainVideoList(title) {
     //if there are videos, show the metadata window, else hide it
     if (oCurrentVideoList.length > 0) {
         if (window.selectedVideoId) showMetaDataByVideoID(window.selectedVideoId);
+        $('#emptyState').attr('hidden', '');
     }
     else {
         closeBox("tdMeta");
+        var hasFilter = (typeof searchVal !== 'undefined' && searchVal && searchVal !== 'Search Videos');
+        $('#emptyStateTitle').text(hasFilter ? 'No videos match your search' : 'No videos found');
+        $('#emptyStateHint').text(hasFilter ? 'Try clearing the search or adjusting your filters.' : 'Sync the database or add videos in Brightcove.');
+        $('#emptyState').removeAttr('hidden');
     }
     hideTableSpinner();
 }
 
 function buildPlaylistList() {
+
+    window.brcCurrentView = 'playlists';
+    $('#bulkActionBar').attr('hidden', '');
 
     //Wipe out the old results
     $("#tbData").empty();
@@ -966,7 +999,7 @@ function buildPlaylistList() {
             "</a></td><td>\
                 <center>---</center>\
             </td><td>"
-            + ((n.reference_id) ? n.reference_id : '') +
+            + ((n.reference_id) ? n.reference_id : '—') +
             "</td><td>"
             + n.id +
             "<span class=\"playlist-actions\"><a href=\"#\" data-playlist=\"" + n.id + "\" data-playlist-name=\"" + n.name + "\"><img src=\"/apps/brightcove/clientlibs/clientlib-tools/img/shared/img/delete.svg\" /></span>" +
@@ -983,6 +1016,15 @@ function buildPlaylistList() {
     }, function () {
         $(this).removeClass("hover");
     });
+
+    if (oCurrentPlaylistList.length > 0) {
+        $('#emptyState').attr('hidden', '');
+    } else {
+        var hasFilter = (typeof searchVal !== 'undefined' && searchVal && searchVal !== 'Search Playlists');
+        $('#emptyStateTitle').text(hasFilter ? 'No playlists match your search' : 'No playlists found');
+        $('#emptyStateHint').text(hasFilter ? 'Try clearing the search.' : 'Create a playlist in Brightcove to see it here.');
+        $('#emptyState').removeAttr('hidden');
+    }
 
     hideTableSpinner();
 }
@@ -1013,6 +1055,9 @@ function createSubPlaylist() {
 }
 
 function showPlaylist() {
+    window.brcCurrentView = 'playlist';
+    $('#bulkActionBar').attr('hidden', '');
+
     //Wipe out the old results
     $("#tbData").empty();
 
@@ -1044,7 +1089,7 @@ function showPlaylist() {
             "</td><td>"
             + (modDate.getMonth() + 1) + "/" + modDate.getDate() + "/" + modDate.getFullYear() + "\
             </td><td>"
-            + ((n.reference_id) ? n.reference_id : '') +
+            + ((n.reference_id) ? n.reference_id : '—') +
             "</td><td>"
             + n.id +
             "</td></tr>"
@@ -2190,6 +2235,7 @@ function toggleSelect(check) {
     } else {
         checkNone();
     }
+    $('body').trigger('brc:checked');
 }
 
 function checkAll() {

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -1016,13 +1016,12 @@ function showPlaylist() {
     //Wipe out the old results
     $("#tbData").empty();
 
-    document.getElementById('divVideoCount').innerHTML = oCurrentVideoList.length + " videos";
-    //$("#divVideoCount").html(oCurrentVideoList.length + " videos");
-    document.getElementById('nameCol').innerHTML = "Video Name";
+    document.getElementById('divVideoCount').innerHTML = oCurrentVideoList.length;
+    document.getElementById('nameCol').innerHTML = "Name<span class='order'></span>";
     document.getElementById('headTitle').innerHTML = oCurrentPlaylistList.name;
     document.getElementById('search').value = "Search Videos";
     $('#searchClear').hide();
-    document.getElementById('searchDiv').style.display = "inline"
+    document.getElementById('searchDiv').style.display = "inline-flex";
     document.getElementById('searchDiv_pl').style.display = "none";
 
     document.getElementById('checkToggle').style.display = "inline"
@@ -2129,13 +2128,12 @@ function doPageList(total, type) {
 	if (type !== "Playlists") {
 	    if (total > paging.size) {
 	        var numOpt = Math.ceil(total / paging.size);
-	        var select = document.getElementsByName("selPageN");
 	        var options = "";
 	        for (var i = 0; i < numOpt; i++) {
 	            options += '<option style="width:100%" id="' + i + '">';
 	            if (paging.generic == i) {
 	                num = (numOpt - 1 == i) ? (total - i * paging.size) : paging.size;
-	                document.getElementById('divVideoCount').innerHTML = num + ' ' + type + ' (of ' + total + ')';
+	                document.getElementById('divVideoCount').innerHTML = num;
 	            }
 	            if (numOpt - 1 == i) {
 	                options += 'Page ' + (i+1) + ' (' + type + ' ' + (i * paging.size + 1) + ' to ' + total + ' )</option>';
@@ -2152,12 +2150,9 @@ function doPageList(total, type) {
 	            }
 	        });
 	        $("div[name=pageDiv]").show();
-	        document.getElementById('tdOne').appendChild(document.getElementById('searchDiv'));
 	    } else {
-	        document.getElementById('divVideoCount').innerHTML = total + ' ' + type + ' (of ' + total + ' )';
+	        document.getElementById('divVideoCount').innerHTML = total;
 	        $("div[name=pageDiv]").hide();
-	        //If there's no page selector, move the search bar down so it doesn't stick out ofplace
-	        document.getElementById('tdTwo').appendChild(document.getElementById('searchDiv'));
 	    }
 	}
 }

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
@@ -38,7 +38,7 @@
                             </svg>
                             <span>Sync database</span>
                         </button>
-                        <div class="brc-account-trigger" id="accountTrigger" tabindex="0" role="button" aria-haspopup="true" aria-expanded="false">
+                        <div class="brc-account-trigger" id="accountTrigger" tabindex="0" role="button" aria-haspopup="true" aria-expanded="false" aria-controls="accountPopover">
                             <div class="brc-account-info" data-sly-list.currentService="${adminPage.configurationServices}">
                                 <sly data-sly-test="${currentService.accountID == adminPage.selectedAccount}">
                                     <div class="brc-account-name">${currentService.accountAlias}</div>
@@ -46,6 +46,21 @@
                                 </sly>
                             </div>
                             <span class="brc-account-caret" aria-hidden="true">⌄</span>
+                        </div>
+                        <div class="brc-account-popover" id="accountPopover" role="menu" hidden>
+                            <div class="brc-account-popover-header">SWITCH ACCOUNT</div>
+                            <div class="brc-account-popover-list" data-sly-list.currentService="${adminPage.configurationServices}">
+                                <button type="button" class="brc-account-row${currentService.accountID == adminPage.selectedAccount ? ' is-active' : ''}"
+                                        data-account-id="${currentService.accountID}"
+                                        data-account-alias="${currentService.accountAlias}"
+                                        role="menuitem">
+                                    <div class="brc-account-row-name">${currentService.accountAlias}</div>
+                                    <div class="brc-account-row-id">${currentService.accountID}</div>
+                                    <sly data-sly-test="${currentService.accountID == adminPage.selectedAccount}">
+                                        <div class="brc-account-row-status">✓ Active</div>
+                                    </sly>
+                                </button>
+                            </div>
                         </div>
                         <select data-sly-list.currentService="${adminPage.configurationServices}" id="selAccount" name="selAccount" hidden>
                             <sly data-sly-test="${currentService.accountID == adminPage.selectedAccount}">

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
@@ -158,6 +158,9 @@
                                                         <span>Show only clips</span>
                                                     </label>
                                                 </div>
+                                                <div class="brc-filter-section brc-filter-section--clear">
+                                                    <button type="button" id="filterClearAll" class="brc-filter-clear-all" hidden>Clear all filters</button>
+                                                </div>
                                             </div>
                                             <div id="pl_search_hint" class="brc-pl-search-hint" style="display:none;">Matches whole words only (e.g. "Smart" finds "Smart Playlist")</div>
                                         </td>

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
@@ -91,6 +91,13 @@
                                                             <path d="M2 4h12M4 8h8M6 12h4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/>
                                                         </svg>
                                                     </button>
+                                                    <div id="bulkActionBar" class="brc-bulk-bar" hidden>
+                                                        <span class="brc-bulk-bar-divider" aria-hidden="true"></span>
+                                                        <span class="brc-bulk-bar-count"><span id="bulkCount">0</span> selected</span>
+                                                        <button type="button" id="bulkCreatePlaylist" class="brc-bulk-bar-btn">Create Playlist</button>
+                                                        <button type="button" id="bulkMoveToFolder" class="brc-bulk-bar-btn menuToggle">Move to Folder</button>
+                                                        <button type="button" id="bulkClear" class="brc-bulk-bar-clear">Clear</button>
+                                                    </div>
                                                 </div>
                                                 <div class="brc-title-row-right">
                                                     <div id="searchDiv" class="brc-pill-search">
@@ -183,6 +190,10 @@
                                             <div class="brc-table-wrapper">
                                                 <div id="tableSpinner" class="brc-table-spinner" hidden>
                                                     <span class="brc-spinner" aria-hidden="true"></span>
+                                                </div>
+                                                <div id="emptyState" class="brc-empty-state" hidden>
+                                                    <p id="emptyStateTitle" class="brc-empty-state-title">No videos match your search or filters</p>
+                                                    <p id="emptyStateHint" class="brc-empty-state-hint">Try clearing the search or adjusting your filters.</p>
                                                 </div>
                                             <table id="tblMainList" cellpadding="3" cellspacing="0">
                                                 <thead>

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
@@ -82,63 +82,77 @@
                                 <table id="listTable" width="100%" cellspacing="0" callpadding="0">
                                     <tr class="trCenterHeader">
                                         <td id="tdOne">
-                                            <div class="result-count pull-left">
-                                                <div id="headTitle" style="font-weight:bold">All Videos</div>
-                                                <div id="divVideoCount" ></div>
-                                            </div>
-
-                                            <div id="searchDiv" style="float:right;padding:5px">
-
-                                                <label class="filter_clips" for="filter_clips" style="display: inline-block; margin-right: 5px;">
-                                                    <input type="checkbox" id="filter_clips">
-                                                    <span style="position: relative;top: -2px; margin-left: 2px;">Show Only Clips</span>
-                                                </label>
-
-                                                <select id='label_list' name="label_list" >
-                                                    <option value="all">All Labels</option>
-                                                </select>
-
-                                                <select id='fldr_list' name="fldr_list" >
-                                                    <option value="all">All Folders</option>
-                                                </select>
-
-                                                <div style="position:relative; display:inline-block;">
-                                                    <input id="search" type="text" value="Search Videos" onClick="if(this.value==='Search Videos') this.value='';">
-                                                    <button type="button" id="searchClear" style="display:none;">&#x2715;</button>
+                                            <div class="brc-title-row">
+                                                <div class="brc-title-row-left">
+                                                    <h2 id="headTitle" class="brc-list-title">All Videos</h2>
+                                                    <div id="divVideoCount" class="brc-count-badge"></div>
+                                                    <button type="button" id="filterToggle" class="brc-filter-btn" aria-expanded="false" aria-controls="filterPanel" title="Filter">
+                                                        <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+                                                            <path d="M2 4h12M4 8h8M6 12h4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/>
+                                                        </svg>
+                                                    </button>
                                                 </div>
-                                                <!--Store the search query in searchBut.value so we can use it as the title of the page once the results are returned.  See searchVideoCallBack -->
-                                                <select id='selField' name="selField" >
-                                                    <option value="every_field">In Every Field</option>
-                                                    <option value="name">In Name</option>
-                                                    <option value="reference_id">In Reference ID</option>
-                                                    <option value="tags">In Tags</option>
-                                                    <option value="text">In Text</option>
-                                                </select>
-                                                <button id="searchBut"
-                                                        onClick="searchVal=document.getElementById('search').value;searchField=document.getElementById('selField').value;Load(searchVideoURL())">
-                                                    Search
-                                                </button>
-                                            </div>
-                                            <div id="searchDiv_pl" style="float:right;padding:5px;display:none;">
-                                                <!--<button id="searchBut" class="btn-create-playlist">
-                                                    Create Playlist
-                                                </button>-->
-                                                <div style="position:relative; display:inline-block; top:5px; height:30px; margin-left:15px;">
-                                                    <input id="search_pl" type="text" value="Search Playlists" onClick="if(this.value==='Search Playlists') this.value='';" style="height:30px;">
-                                                    <button type="button" id="searchClear_pl" style="display:none;">&#x2715;</button>
+                                                <div class="brc-title-row-right">
+                                                    <div id="searchDiv" class="brc-pill-search">
+                                                        <span class="brc-pill-search-icon" aria-hidden="true">
+                                                            <svg width="14" height="14" viewBox="0 0 16 16">
+                                                                <circle cx="7" cy="7" r="5" stroke="currentColor" stroke-width="1.5" fill="none"/>
+                                                                <path d="m11 11 3.5 3.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+                                                            </svg>
+                                                        </span>
+                                                        <input id="search" class="brc-pill-search-input" type="text" placeholder="Search video by name or ID" value="Search Videos" onClick="if(this.value==='Search Videos') this.value='';">
+                                                        <button type="button" id="searchClear" class="brc-pill-search-clear" style="display:none;" aria-label="Clear search">&#x2715;</button>
+                                                        <select id="selField" name="selField" class="brc-pill-search-field">
+                                                            <option value="every_field">Every field</option>
+                                                            <option value="name">Name</option>
+                                                            <option value="reference_id">Reference ID</option>
+                                                            <option value="tags">Tags</option>
+                                                            <option value="text">Text</option>
+                                                        </select>
+                                                        <button id="searchBut" class="brc-pill-search-go"
+                                                                onClick="searchVal=document.getElementById('search').value;searchField=document.getElementById('selField').value;Load(searchVideoURL())">Search</button>
+                                                    </div>
+                                                    <div id="searchDiv_pl" class="brc-pill-search" style="display:none;">
+                                                        <span class="brc-pill-search-icon" aria-hidden="true">
+                                                            <svg width="14" height="14" viewBox="0 0 16 16">
+                                                                <circle cx="7" cy="7" r="5" stroke="currentColor" stroke-width="1.5" fill="none"/>
+                                                                <path d="m11 11 3.5 3.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+                                                            </svg>
+                                                        </span>
+                                                        <input id="search_pl" class="brc-pill-search-input" type="text" placeholder="Search playlist by name or ID" value="Search Playlists" onClick="if(this.value==='Search Playlists') this.value='';">
+                                                        <button type="button" id="searchClear_pl" class="brc-pill-search-clear" style="display:none;" aria-label="Clear search">&#x2715;</button>
+                                                        <select id="selField_pl" name="selField_pl" class="brc-pill-search-field" onchange="togglePlSearchHint(this.value)">
+                                                            <option value="find_playlist_by_name">Name</option>
+                                                            <option value="find_playlist_by_id">Playlist ID</option>
+                                                            <option value="find_playlist_by_reference_id">Reference ID</option>
+                                                        </select>
+                                                        <button id="searchBut_pl" class="brc-pill-search-go"
+                                                                onClick="searchVal=document.getElementById('search_pl').value;searchField=document.getElementById('selField_pl').value;Load(getFindPlaylistsURL())">Search</button>
+                                                    </div>
                                                 </div>
-                                                <!--Store the search query in searchBut.value so we can use it as the title of the page once the results are returned.  See searchVideoCallBack -->
-                                                <select id='selField_pl' name="selField_pl" style="position: relative;top: 5px;" onchange="togglePlSearchHint(this.value)">
-                                                    <option value="find_playlist_by_name">Name</option>
-                                                    <option value="find_playlist_by_id">Playlist ID</option>
-                                                    <option value="find_playlist_by_reference_id">Reference ID</option>
-                                                </select>
-                                                <button id="searchBut" onClick="searchVal=document.getElementById('search_pl').value;searchField=document.getElementById('selField_pl').value;Load(getFindPlaylistsURL())">
-                                                    Search
-                                                </button>
-                                                <div id="pl_search_hint" style="font-size:11px;color:#666;margin-top:4px;margin-left:15px;">Matches whole words only (e.g. "Smart" finds "Smart Playlist")</div>
                                             </div>
-
+                                            <div id="filterPanel" class="brc-filter-panel" hidden>
+                                                <div class="brc-filter-section">
+                                                    <div class="brc-filter-label">LABELS</div>
+                                                    <select id="label_list" name="label_list" class="brc-filter-select">
+                                                        <option value="all">All Labels</option>
+                                                    </select>
+                                                </div>
+                                                <div class="brc-filter-section">
+                                                    <div class="brc-filter-label">FOLDER</div>
+                                                    <select id="fldr_list" name="fldr_list" class="brc-filter-select">
+                                                        <option value="all">All Folders</option>
+                                                    </select>
+                                                </div>
+                                                <div class="brc-filter-section">
+                                                    <div class="brc-filter-label">CLIPS ONLY</div>
+                                                    <label class="brc-filter-checkbox" for="filter_clips">
+                                                        <input type="checkbox" id="filter_clips">
+                                                        <span>Show only clips</span>
+                                                    </label>
+                                                </div>
+                                            </div>
+                                            <div id="pl_search_hint" class="brc-pl-search-hint" style="display:none;">Matches whole words only (e.g. "Smart" finds "Smart Playlist")</div>
                                         </td>
                                     </tr>
 

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
@@ -27,10 +27,8 @@
                 <!--Navbar-->
                 <header class="brc-header">
                     <div class="brc-tabs" role="tablist">
-                        <button type="button" id="allVideos" class="brc-tab is-active" role="tab" aria-selected="true"
-                                onclick='searchVal="";document.querySelectorAll(".brc-tab").forEach(function(t){t.classList.remove("is-active");t.setAttribute("aria-selected","false");});this.classList.add("is-active");this.setAttribute("aria-selected","true");Load(getAllVideosURL());'>Videos</button>
-                        <button type="button" id="allPlaylists" class="brc-tab" role="tab" aria-selected="false"
-                                onclick='searchVal="";document.querySelectorAll(".brc-tab").forEach(function(t){t.classList.remove("is-active");t.setAttribute("aria-selected","false");});this.classList.add("is-active");this.setAttribute("aria-selected","true");Load(getAllPlaylistsURL());'>Playlists</button>
+                        <button type="button" id="allVideos" class="brc-tab is-active" role="tab" aria-selected="true">Videos</button>
+                        <button type="button" id="allPlaylists" class="brc-tab" role="tab" aria-selected="false">Playlists</button>
                     </div>
                     <h1 class="brc-title">Brightcove Admin</h1>
                     <div class="brc-header-actions">

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
@@ -25,27 +25,40 @@
         <body>
             <div id="brightcove">
                 <!--Navbar-->
-                <div class="navbar">
-                    <div class="navbar-inner">
-                        <div class="container">
-                            <ul class="nav nav-pills visible-lg-inline-block">
-                                <li class="active">
-                                    <a id="allVideos" onclick='searchVal="";$(this).parent("li").parent("ul").children("li").attr("class","");$(this).parent("li").attr("class","active");Load(getAllVideosURL());'>All Videos</a>
-                                </li>
-                                <li>
-                                    <a id="allPlaylists" onclick='searchVal="";$(this).parent("li").parent("ul").children("li").attr("class","");$(this).parent("li").attr("class","active");Load(getAllPlaylistsURL())'>All Playlists</a>
-                                </li>
-                            </ul>
-                            <div class="pull-right">
-                                <div>
-                                    <button type="button" id="syncdbutton" alt="Brightcove Dataload" onClick="syncDB()">Sync Database</button>
-                                    <img src="/apps/brightcove/clientlibs/clientlib-tools/img/shared/img/logo-2022.svg" alt="Brightcove Console" width="125">
-                                </div>
-                            </div>
-
-                        </div>
+                <header class="brc-header">
+                    <div class="brc-tabs" role="tablist">
+                        <button type="button" id="allVideos" class="brc-tab is-active" role="tab" aria-selected="true"
+                                onclick='searchVal="";document.querySelectorAll(".brc-tab").forEach(function(t){t.classList.remove("is-active");t.setAttribute("aria-selected","false");});this.classList.add("is-active");this.setAttribute("aria-selected","true");Load(getAllVideosURL());'>Videos</button>
+                        <button type="button" id="allPlaylists" class="brc-tab" role="tab" aria-selected="false"
+                                onclick='searchVal="";document.querySelectorAll(".brc-tab").forEach(function(t){t.classList.remove("is-active");t.setAttribute("aria-selected","false");});this.classList.add("is-active");this.setAttribute("aria-selected","true");Load(getAllPlaylistsURL());'>Playlists</button>
                     </div>
-                </div>
+                    <h1 class="brc-title">Brightcove Admin</h1>
+                    <div class="brc-header-actions">
+                        <button type="button" id="syncdbutton" class="brc-sync-btn" alt="Brightcove Dataload" onClick="syncDB()">
+                            <svg class="brc-sync-icon" width="13" height="13" viewBox="0 0 16 16" aria-hidden="true">
+                                <path d="M14 8a6 6 0 1 1-1.757-4.243M14 2v4h-4" stroke="currentColor" stroke-width="1.6" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+                            </svg>
+                            <span>Sync database</span>
+                        </button>
+                        <div class="brc-account-trigger" id="accountTrigger" tabindex="0" role="button" aria-haspopup="true" aria-expanded="false">
+                            <div class="brc-account-info" data-sly-list.currentService="${adminPage.configurationServices}">
+                                <sly data-sly-test="${currentService.accountID == adminPage.selectedAccount}">
+                                    <div class="brc-account-name">${currentService.accountAlias}</div>
+                                    <div class="brc-account-id">${currentService.accountID}</div>
+                                </sly>
+                            </div>
+                            <span class="brc-account-caret" aria-hidden="true">⌄</span>
+                        </div>
+                        <select data-sly-list.currentService="${adminPage.configurationServices}" id="selAccount" name="selAccount" hidden>
+                            <sly data-sly-test="${currentService.accountID == adminPage.selectedAccount}">
+                                <option value="${currentService.accountID}" class="selected" selected="selected">${currentService.accountAlias} (${currentService.accountID})</option>
+                            </sly>
+                            <sly data-sly-test="${currentService.accountID != adminPage.selectedAccount}">
+                                <option value="${currentService.accountID}">${currentService.accountAlias} (${currentService.accountID})</option>
+                            </sly>
+                        </select>
+                    </div>
+                </header>
                 <!--(end) Navbar-->
 
                 <div id="divConsole">
@@ -54,19 +67,6 @@
                             <!-- Start center column -->
                             <td width="75%" valign="top">
                                 <table id="listTable" width="100%" cellspacing="0" callpadding="0">
-                                    <tr>
-                                        <div id="accountDiv" style="float:right;padding:5px;
-                                        margin-bottom: 10px;">
-                                            <select data-sly-list.currentService="${adminPage.configurationServices}" id='selAccount' name="selAccount" style="position: relative;top: 5px;">
-                                                <sly data-sly-test="${currentService.accountID == adminPage.selectedAccount}">
-                                                    <option value="${currentService.accountID}" class="selected" selected="selected">${currentService.accountAlias} (${currentService.accountID})</option>
-                                                </sly>
-                                                <sly data-sly-test="${currentService.accountID != adminPage.selectedAccount}">
-                                                    <option value="${currentService.accountID}">${currentService.accountAlias} (${currentService.accountID})</option>
-                                                </sly>
-                                            </select>
-                                        </div>
-                                    </tr>
                                     <tr class="trCenterHeader">
                                         <td id="tdOne">
                                             <div class="result-count pull-left">

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
@@ -95,7 +95,14 @@
                                                         <span class="brc-bulk-bar-divider" aria-hidden="true"></span>
                                                         <span class="brc-bulk-bar-count"><span id="bulkCount">0</span> selected</span>
                                                         <button type="button" id="bulkCreatePlaylist" class="brc-bulk-bar-btn">Create Playlist</button>
-                                                        <button type="button" id="bulkMoveToFolder" class="brc-bulk-bar-btn menuToggle">Move to Folder</button>
+                                                        <span class="brc-bulk-move-wrapper">
+                                                            <button type="button" id="bulkMoveToFolder" class="brc-bulk-bar-btn menuToggle">Move to Folder</button>
+                                                            <div class="folder-selector menu" data-bulk="true">
+                                                                <ul class="menu-options">
+                                                                    <li class="menu-option remove" data-folder-id="none">[No Folder]</li>
+                                                                </ul>
+                                                            </div>
+                                                        </span>
                                                         <button type="button" id="bulkClear" class="brc-bulk-bar-clear">Clear</button>
                                                     </div>
                                                 </div>

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
@@ -36,7 +36,7 @@
                             <svg class="brc-sync-icon" width="13" height="13" viewBox="0 0 16 16" aria-hidden="true">
                                 <path d="M14 8a6 6 0 1 1-1.757-4.243M14 2v4h-4" stroke="currentColor" stroke-width="1.6" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
                             </svg>
-                            <span>Sync database</span>
+                            <span class="brc-sync-btn-label">Sync database</span>
                         </button>
                         <div class="brc-account-trigger" id="accountTrigger" tabindex="0" role="button" aria-haspopup="true" aria-expanded="false" aria-controls="accountPopover">
                             <div class="brc-account-info" data-sly-list.currentService="${adminPage.configurationServices}">

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
@@ -184,10 +184,10 @@
                                                 <thead>
                                                 <tr id="trHeader">
                                                     <th id="checkCol" class="tdMainTableHead" style="border-right:0px;color:#e5e5e5;font-size:1px"><input type="checkbox" onclick="toggleSelect(this)" id="checkToggle"/>?</th>
-                                                    <th id="nameCol" class="tdMainTableHead sortable ASC" style="border-left:0px" data-sortType="" data-sortBy="name" onclick="sort(this)">Video Name <span class='order'></span></th>
+                                                    <th id="nameCol" class="tdMainTableHead sortable ASC" style="border-left:0px" data-sortType="" data-sortBy="name" onclick="sort(this)">Name<span class='order'></span></th>
                                                     <th id="lastUpdated" class="tdMainTableHead sortable NONE" data-sortType="-" data-sortBy="updated_at" onclick="sort(this)">Last Updated <span class='order'></span></th>
-                                                    <th class="tdMainTableHead sortable NONE" data-sortType="" data-sortBy="reference_id" onclick="sort(this)">Reference Id <span class='order'></span></th>
-                                                    <th class="tdMainTableHead">ID</th>
+                                                    <th class="tdMainTableHead sortable NONE" data-sortType="" data-sortBy="reference_id" onclick="sort(this)">Reference ID <span class='order'></span></th>
+                                                    <th class="tdMainTableHead sortable NONE" data-sortType="" data-sortBy="id" onclick="sort(this)">ID <span class='order'></span></th>
                                                 </tr>
                                                 </thead>
                                                 <tbody id="tbData"></tbody>

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
@@ -180,6 +180,10 @@
                                         <td>
                                             <!-- Start Main list -->
                                             <!-- buildMainVideoList, buildPlaylistList and showPlaylist populate this section, -->
+                                            <div class="brc-table-wrapper">
+                                                <div id="tableSpinner" class="brc-table-spinner" hidden>
+                                                    <span class="brc-spinner" aria-hidden="true"></span>
+                                                </div>
                                             <table id="tblMainList" cellpadding="3" cellspacing="0">
                                                 <thead>
                                                 <tr id="trHeader">
@@ -192,6 +196,7 @@
                                                 </thead>
                                                 <tbody id="tbData"></tbody>
                                             </table>
+                                            </div>
                                         </td>
                                     </tr>
                                     <tr>


### PR DESCRIPTION
## Summary

Implements BCON-121 (header / nav revamp), BCON-141 (videos list table), and BCON-142 (search + filter panel) on top of PR #87.

**Frames covered:**
- A — Videos: Default
- B — Videos: Filters Open
- C — Videos: 1 Selected (BCON-141 bulk action bar + selected-row treatment)
- E — Account Switcher Open

This PR is **stacked on top of #87** (`feature/cloud-master/admin-ui-fixes`) so the BCON-128/131 search-input work integrates naturally into the new layout instead of being lost in a navbar-rewrite merge conflict. After #87 merges, retarget this PR's base to `cloud-master` (one click — no rebase needed).

## BCON-121 — Header & nav

- **Header** restyled: tan `#f0efea` with `#e8e6df` bottom border, tab pill group on the left (active = white card with `#e8e6df` border, semibold), centered "Brightcove Admin" title, black-filled "Sync database" button, account selector trigger showing alias + ID. Body wrapper flattened so the header runs flush. AEM-injected `<betty-titlebar>` hidden so our header is the only top chrome.
- **Account switcher**: custom 240px popover (Frame E) replacing the native `<select>`. SWITCH ACCOUNT header strip, active-account block on `#f7f6f2` with "✓ Active", switchable rows with `#e8e6df` dividers. Open on trigger click, dismiss on outside click / Escape.
- **Account-switch toast** (post-reload, `Switched to <alias>`) — `sessionStorage` flag set before reload, read and cleared on `$(document).ready`.
- **Title row** restructured: list title + count badge + filter toggle button on the left, pill-shaped search bar on the right.
- **Tab handlers** moved from inline `onclick` mess into a single delegated jQuery handler.
- **Tab-switch spinner**: scoped black CSS spinner over the table area only.
- **Pagination/count cleanup** — `doPageList()` no longer reflows `#searchDiv` between `#tdOne` and `#tdTwo`; count badge shows just the number.

## BCON-141 — Videos list table

- **Bulk action bar** (Frame C) lives in the title row, hidden by default, shown when ≥1 video row is checked. Carries `N selected` + Create Playlist + Move to Folder + Clear, delegating to the existing `createPlaylistBox` / `moveVideoToFolder` handlers.
- **Selected-row treatment**: `#f0efea` row background; checkbox flips to filled black `#1a1a18` with a white check via `appearance: none` + `::after`. Master `#checkToggle` now triggers `brc:checked` so the bulk bar stays in sync.
- **Empty state**: when `oCurrentVideoList.length === 0` (or playlist equivalent), a centered context-aware message renders below the table header.
- **Reference ID em-dash**: rows with no `reference_id` render `—` instead of an empty cell.
- **Table styling**: 44px white header on `#e8e6df` borders, Inter Bold 13 column titles, sort glyphs as inline `↑` / `↓` / `↕`, 52px rows with `#f0efea` dividers.

## BCON-142 — Search & filter panel

- **Filter panel** (BCON-121 already added this): collapsible card with LABELS / FOLDER / CLIPS ONLY sections, matching Figma B.
- **Active-filter indicator**: filter button gets a small black dot affordance when any of label / folder / clips is in a non-default state.
- **Clear-all filters**: new link inside the filter panel, hidden when no filters are active. Resets all three controls and triggers `Load(getAllVideosURL())`.
- **Clips-only empty state**: clips is a DOM-only filter, so its handler now surfaces the empty state directly when zero rows remain visible ("No clips in this list").
- **Custom checkbox style** extended to the Show-only-clips toggle so it matches the table-row checkboxes.
- **State persistence** kept as current behavior (within-session, no cross-reload persistence).

## Out of scope (flagged for separate tickets)

- **Detail Panel** + Variant Details modal shown in Frames C and D — confirmed out of scope after re-reading BCON-141 and BCON-142 ACs (the AC #7 of BCON-142 references Frame D for layout parity, but the Detail Panel itself isn't called out in any AC bullet).

## Files touched

- `current/ui.apps/.../components/tools/brightcoveadmin/brightcoveadmin.html`
- `current/ui.apps/.../clientlibs/clientlib-tools/css/style.css`
- `current/ui.apps/.../clientlibs/clientlib-tools/js/brcUI.js`
- `current/ui.apps/.../clientlibs/clientlib-tools/js/brcAdmin.js` (no functional change — the tab handlers moved out of inline `onclick` into brcUI.js' init block)

## Verification

Two Playwright smoke tests run against the live local AEM:
- BCON-121 / general header & nav: 39/40 (1 pre-existing AEM-Granite 404 unchanged on master)
- BCON-141 bulk-bar / selected-row / em-dash / empty-state: 10/10
- BCON-142 active-filter dot / clear-all / clips empty-state: 5/5

## Items not in the Figma frames

- Black tab-switch spinner — Figma doesn't show one; implemented as a scoped CSS spinner over the table area.
- Account-switch toast — also not in any frame; black pill toast at the bottom-center, ~3s.
- Active-filter indicator — Figma doesn't show one; implemented as a small black dot on the filter button.
- Filter panel default state — closed.

## Test plan

- [ ] **Frame A parity** — tan header, "Videos" pill active, centered title, black sync button, account selector with alias + ID; title row shows "All Videos" + count badge + filter button on the left and a pill search at the right.
- [ ] **Frame B parity** — clicking the filter toggle reveals the LABELS / FOLDER / CLIPS ONLY card; clicking again hides it.
- [ ] **Frame C parity** — selecting a row reveals the bulk bar with `1 selected` + Create Playlist + Move to Folder + Clear; selected row background is tan; checkbox shows filled black with white check; selecting more rows updates the count; Clear deselects everything and hides the bar.
- [ ] **Frame E parity** — clicking the account trigger opens the 240px popover; outside-click and Escape dismiss.
- [ ] **Tab switch** — Videos ↔ Playlists shows the black spinner; pill search swaps; on Playlists the filter button + bulk bar are hidden.
- [ ] **Account switch toast** — after reload, "Switched to <alias>" toast slides up and auto-dismisses.
- [ ] **Sync flow** — button enters loading state, brand overlay shows, finishes cleanly. Sync button stays white-on-black through normal video/playlist loads.
- [ ] **Empty state** — search for something nonsense; the "No videos match your search" message renders.
- [ ] **Reference ID em-dash** — rows without a Reference ID show `—`.
- [ ] **Active-filter indicator** — selecting a label / folder / clips-only adds a dot on the filter button; clearing removes it.
- [ ] **Clear all filters** — the link appears in the filter panel only when ≥1 filter is active; clicking resets everything.
- [ ] **PR #87 features** — pill search X clear button works on both Videos and Playlists; playlist name-search returns partial matches; the hint surfaces when name mode is selected.