### PR TITLE
chore(security): remove dead commented buildJSONRequest example with legacy token

### DIFF
--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/cq-widgets/source/js/brightcoveUpload.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/cq-widgets/source/js/brightcoveUpload.js
@@ -49,15 +49,6 @@ function doFileUpload() {
 
 }
 
-/*function buildJSONRequest(form){
- if($CQ('#name').val() =="" || $CQ('#shortDescription').val() =="" || $CQ("#filePath").val() ==""){
- alert("Require Name, Short Description and File");
- return;
- }else{
- $CQ('#JSONRPC').val('{"method": "create_video", "params": {"video": {"name": "' + $CQ('#name').val() + '", "shortDescription": "' + $CQ('#shortDescription').val() + '"},"token": "c9hG9CFjGaY6mguNiD7BKaYBZ2YCrCdoMlgV1y8LRgKNKgl-38duog.."}}');
- }
- }*/
-
 function showModalWindow() {
     //transition effect
     $CQ("#tagBCUpload").html('<p><a id="tagHref" href="#bcUpload" onclick="hideModalWindow(); return false;">Close Upload Window</a></p>');


### PR DESCRIPTION
## Summary
Removes a dead, commented-out `buildJSONRequest` example in `current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/cq-widgets/source/js/brightcoveUpload.js` whose payload contained a hardcoded legacy Brightcove Media API write token. The block was inside a `/* ... */` comment and never executed; the active upload flow uses the `buildJSONRequest` defined in `clientlib-tools/js/brcAdmin.js`, which contains no token.

## Why
Triggered a secret-scanning alert on the public repo. Investigation:
- Token format matches the legacy Brightcove Media API write token (base64url with trailing `..`).
- Endpoint referenced (`api.brightcove.com/services/post`) is the decommissioned Media API; current Brightcove APIs use OAuth 2.0 bearer tokens, which this format is incompatible with.
- Introduced in the initial 2017 commit by the original third-party Coresecure author — predates Brightcove ownership of the codebase.

## On git history
Not rewriting history. The repo has been public since 2017, so the value has long been crawled/archived/forked; a force-push gains no security benefit and would break every clone and fork. Mitigation is fix-forward + (symbolic) rotation confirmation with the Brightcove security/auth team.

## Companion PRs
This same one-commit deletion is being applied to `master`, `onprem-master`, `release/7.0.0-cloud`, `release/6.1.11-cloud`, and `release/6.0.11` so the dead comment is gone from every actively-maintained line.

## Test plan
- [ ] Diff is a pure deletion (9 lines, comment block only).
- [ ] No live code path is affected — the surrounding `buildJSONRequest` was already commented out.