### PR TITLE
feat(BCON-146): add Move to Folder modal and bump version to 7.1.4

### DIFF
--- a/current/all/pom.xml
+++ b/current/all/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.3</version>
+        <version>7.1.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/analyse/pom.xml
+++ b/current/analyse/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.3</version>
+        <version>7.1.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/core/pom.xml
+++ b/current/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.3</version>
+        <version>7.1.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>brightcove.core</artifactId>

--- a/current/it.tests/pom.xml
+++ b/current/it.tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.3</version>
+        <version>7.1.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/pom.xml
+++ b/current/pom.xml
@@ -21,7 +21,7 @@
     <groupId>com.coresecure</groupId>
     <artifactId>brightcove</artifactId>
     <packaging>pom</packaging>
-    <version>7.1.3</version>
+    <version>7.1.4</version>
     <description>Brightcove Connector</description>
 
     <modules>

--- a/current/ui.apps.structure/pom.xml
+++ b/current/ui.apps.structure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.3</version>
+        <version>7.1.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.apps/pom.xml
+++ b/current/ui.apps/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.3</version>
+        <version>7.1.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -2330,5 +2330,280 @@ body {
   margin-right: .2rem;
 }
 
+/* ---- BCON-146: Move to Folder Modal ---- */
+
+.brc-mtf-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(26, 26, 24, 0.6);
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.brc-mtf-overlay[hidden] {
+  display: none;
+}
+
+body.brc-mtf-open {
+  overflow: hidden;
+}
+
+.brc-mtf-container {
+  background: #fff;
+  border-radius: 16px;
+  width: 480px;
+  max-width: calc(100vw - 40px);
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 80px);
+  font-family: 'Inter', adobe-clean, Helvetica, Arial, sans-serif;
+  overflow: hidden;
+  box-shadow: 0 8px 32px rgba(26, 26, 24, 0.18);
+}
+
+.brc-mtf-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 24px 24px 20px;
+  flex-shrink: 0;
+}
+
+.brc-mtf-title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.brc-mtf-title {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 700;
+  color: #1a1a18;
+  line-height: 1.2;
+  font-family: inherit;
+}
+
+.brc-mtf-subtitle {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 400;
+  color: #6b7280;
+}
+
+.brc-mtf-close {
+  background: none;
+  background-image: none;
+  background-color: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  color: #6b7280;
+  font-size: 18px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  flex-shrink: 0;
+  box-shadow: none;
+  filter: none;
+  text-shadow: none;
+  text-transform: none;
+}
+
+.brc-mtf-close:hover {
+  color: #1a1a18;
+  background: #f0efea;
+  background-color: #f0efea;
+}
+
+.brc-mtf-search-wrap {
+  padding: 0 20px 16px;
+  flex-shrink: 0;
+}
+
+.brc-mtf-search {
+  width: 100%;
+  height: 40px;
+  border: 1.5px solid #e8e6df;
+  border-radius: 10px;
+  padding: 0 14px;
+  font-family: inherit;
+  font-size: 13px;
+  color: #1a1a18;
+  outline: none;
+  background: #fff;
+  box-sizing: border-box;
+}
+
+.brc-mtf-search::placeholder {
+  color: #9ca3af;
+}
+
+.brc-mtf-search:focus {
+  border-color: #c8c7c2;
+  outline: none;
+}
+
+.brc-mtf-list-wrap {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  min-height: 0;
+  scrollbar-width: thin;
+  scrollbar-color: #e8e6df transparent;
+}
+
+.brc-mtf-list-wrap::-webkit-scrollbar {
+  width: 4px;
+}
+
+.brc-mtf-list-wrap::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.brc-mtf-list-wrap::-webkit-scrollbar-thumb {
+  background: #e8e6df;
+  border-radius: 4px;
+}
+
+.brc-mtf-list-header {
+  padding: 8px 20px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #1a1a18;
+  background: #f7f6f2;
+  border-top: 1px solid #f0efea;
+  border-bottom: 1px solid #f0efea;
+}
+
+.brc-mtf-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.brc-mtf-list-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 20px;
+  border-bottom: 1px solid #f0efea;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 400;
+  color: #1a1a18;
+}
+
+.brc-mtf-list-item:last-child {
+  border-bottom: none;
+}
+
+.brc-mtf-list-item:hover {
+  background: #f7f6f2;
+}
+
+.brc-mtf-list-item.is-selected {
+  background: #f7f6f2;
+}
+
+.brc-mtf-folder-icon {
+  flex-shrink: 0;
+  color: #6b7280;
+}
+
+.brc-mtf-folder-name {
+  flex: 1;
+}
+
+.brc-mtf-check {
+  flex-shrink: 0;
+  visibility: hidden;
+  color: #1a1a18;
+}
+
+.brc-mtf-list-item.is-selected .brc-mtf-check {
+  visibility: visible;
+}
+
+.brc-mtf-empty {
+  padding: 24px 20px;
+  text-align: center;
+  font-size: 13px;
+  color: #6b7280;
+  list-style: none;
+}
+
+.brc-mtf-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 16px 20px;
+  border-top: 1px solid #f0efea;
+  flex-shrink: 0;
+}
+
+.brc-mtf-btn-cancel {
+  height: 40px;
+  padding: 0 20px;
+  background: transparent;
+  background-image: none;
+  background-color: transparent;
+  border: 1.5px solid #e8e6df;
+  border-radius: 10px;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 500;
+  color: #1a1a18;
+  cursor: pointer;
+  box-shadow: none;
+  filter: none;
+  text-shadow: none;
+  text-transform: none;
+  margin: 0;
+}
+
+.brc-mtf-btn-cancel:hover {
+  background: #f7f6f2;
+  background-color: #f7f6f2;
+}
+
+.brc-mtf-btn-move {
+  height: 40px;
+  padding: 0 20px;
+  background: #c8c7c2;
+  background-image: none;
+  background-color: #c8c7c2;
+  border: none;
+  border-radius: 10px;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 500;
+  color: #fff;
+  cursor: default;
+  box-shadow: none;
+  filter: none;
+  text-shadow: none;
+  text-transform: none;
+  margin: 0;
+}
+
+.brc-mtf-btn-move:not([disabled]) {
+  background: #1a1a18;
+  background-color: #1a1a18;
+  cursor: pointer;
+}
+
+.brc-mtf-btn-move:not([disabled]):hover {
+  background: #2a2a26;
+  background-color: #2a2a26;
+}
+
 /* ---------- END NEW CSS --------------- */
 

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -98,6 +98,8 @@ function brcToast(message) {
 var $ACTIVE_TRACKS;
 var $sortable;
 var brc_admin = brc_admin || {};
+var _mtfAllFolders = [];
+var _mtfSelectedFolderId = null;
 
 
 //tUploadBar has the timer id for the upload progress bar, so it can be cancelled.  progressPos is used to keep track of the progress bar's position.
@@ -641,11 +643,123 @@ function suggestVideosForPlaylist(data) {
 }
 
 function moveVideoToFolder() {
-    var $sel = window.brcCurrentView === 'playlist'
-        ? $('.butDiv .folder-selector')
-        : $('#bulkActionBar .folder-selector');
-    $sel.toggleClass('open');
+    openMoveToFolderModal();
 }
+
+function openMoveToFolderModal() {
+    var count = paging.selectedVideos.length;
+    $('#mtfSubtitle').text(count + ' video' + (count !== 1 ? 's' : '') + ' selected');
+    $('#mtfSearch').val('');
+    _mtfSelectedFolderId = null;
+    $('#mtfMove').prop('disabled', true);
+
+    if (_mtfAllFolders.length > 0) {
+        renderMtfFolders(_mtfAllFolders);
+    } else {
+        $('#mtfFolderList').html('<li class="brc-mtf-empty">Loading\u2026</li>');
+        $.ajax({
+            type: 'GET',
+            url: '/bin/brightcove/api.js',
+            data: { a: 'list_folders', account_id: $('#selAccount').val(), callback: 'mtfFolderLoadCallback' },
+            async: true
+        });
+    }
+
+    $('body').addClass('brc-mtf-open');
+    $('#moveToFolderModal').removeAttr('hidden');
+}
+
+function mtfFolderLoadCallback(data) {
+    _mtfAllFolders = (data && data.items) ? data.items : [];
+    renderMtfFolders(_mtfAllFolders);
+}
+
+function closeMoveToFolderModal() {
+    $('#moveToFolderModal').attr('hidden', '');
+    $('body').removeClass('brc-mtf-open');
+    _mtfSelectedFolderId = null;
+}
+
+function renderMtfFolders(folders) {
+    var q = $('#mtfSearch').val().toLowerCase();
+    var filtered = q ? folders.filter(function (f) {
+        return f.name.toLowerCase().indexOf(q) !== -1;
+    }) : folders;
+
+    var $list = $('#mtfFolderList').empty();
+
+    if (filtered.length === 0) {
+        $list.html('<li class="brc-mtf-empty">No folders found.</li>');
+        return;
+    }
+
+    var folderSvg = '<svg class="brc-mtf-folder-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">'
+        + '<path d="M1.5 4.5A1 1 0 0 1 2.5 3.5H6L7.5 5H13.5A1 1 0 0 1 14.5 6V12.5A1 1 0 0 1 13.5 13.5H2.5A1 1 0 0 1 1.5 12.5V4.5Z" stroke="#6b7280" stroke-width="1.25"/>'
+        + '</svg>';
+    var checkSvg = '<svg class="brc-mtf-check" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">'
+        + '<path d="M3 8l3.5 3.5L13 5" stroke="#1a1a18" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" fill="none"/>'
+        + '</svg>';
+
+    $.each(filtered, function (i, folder) {
+        var isSelected = folder.id === _mtfSelectedFolderId;
+        var $li = $('<li>')
+            .addClass('brc-mtf-list-item' + (isSelected ? ' is-selected' : ''))
+            .attr('data-folder-id', folder.id)
+            .append($(folderSvg))
+            .append($('<span class="brc-mtf-folder-name">').text(folder.name))
+            .append($(checkSvg));
+        $list.append($li);
+    });
+}
+
+$(function () {
+    $(document).on('click', '.brc-mtf-list-item', function () {
+        var folderId = $(this).data('folder-id');
+        if (_mtfSelectedFolderId === folderId) {
+            _mtfSelectedFolderId = null;
+            $(this).removeClass('is-selected');
+            $('#mtfMove').prop('disabled', true);
+        } else {
+            _mtfSelectedFolderId = folderId;
+            $('.brc-mtf-list-item').removeClass('is-selected');
+            $(this).addClass('is-selected');
+            $('#mtfMove').prop('disabled', false);
+        }
+    });
+
+    $('#mtfSearch').on('input', function () {
+        renderMtfFolders(_mtfAllFolders);
+    });
+
+    $('#mtfClose, #mtfCancel').on('click', function () {
+        closeMoveToFolderModal();
+    });
+
+    $('#moveToFolderModal').on('click', function (e) {
+        if (e.target === this) closeMoveToFolderModal();
+    });
+
+    $('#mtfMove').on('click', function () {
+        if ($(this).prop('disabled') || !_mtfSelectedFolderId) return;
+        var folderId = _mtfSelectedFolderId;
+        var accountId = $('#selAccount').val();
+        $.each(paging.selectedVideos, function (i, checkbox) {
+            $.ajax({
+                type: 'GET',
+                url: '/bin/brightcove/api.js',
+                data: {
+                    a: 'move_video_to_folder',
+                    folder: folderId,
+                    video: $(checkbox).val(),
+                    account_id: accountId
+                },
+                async: true
+            });
+        });
+        closeMoveToFolderModal();
+        $('#fldr_list').change();
+    });
+});
 
 function getMoveVideoToFolderUrl(video_id, folder_id) {
     loadStart();
@@ -708,6 +822,7 @@ function loadFolders() {
 function loadFolderCallback(data) {
     var $folder_select = $('#fldr_list');
     var $move_folder_list = $('.folder-selector .menu-options');
+    _mtfAllFolders = (data && data.items) ? data.items : [];
     $.each(data.items, function (i, n) {
         $folder_select
             .append($('<option>', { value : n.id }).text(n.name));

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -714,7 +714,7 @@ function renderMtfFolders(folders) {
 
 $(function () {
     $(document).on('click', '.brc-mtf-list-item', function () {
-        var folderId = $(this).data('folder-id');
+        var folderId = $(this).attr('data-folder-id');
         if (_mtfSelectedFolderId === folderId) {
             _mtfSelectedFolderId = null;
             $(this).removeClass('is-selected');

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
@@ -462,7 +462,7 @@
                                 <input type="text" id="mtfSearch" class="brc-mtf-search" placeholder="Search Folder" autocomplete="off">
                             </div>
                             <div class="brc-mtf-list-wrap">
-                                <div class="brc-mtf-list-header">All Videos</div>
+                                <div class="brc-mtf-list-header">All Folders</div>
                                 <ul class="brc-mtf-list" id="mtfFolderList"></ul>
                             </div>
                             <div class="brc-mtf-footer">

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
@@ -448,6 +448,30 @@
                         </div>
                     </div>
 
+                    <!-- Move to Folder Modal (BCON-146) -->
+                    <div id="moveToFolderModal" class="brc-mtf-overlay" hidden aria-modal="true" role="dialog" aria-labelledby="mtfTitle">
+                        <div class="brc-mtf-container">
+                            <div class="brc-mtf-header">
+                                <div class="brc-mtf-title-group">
+                                    <h2 class="brc-mtf-title" id="mtfTitle">Move to Folder</h2>
+                                    <p class="brc-mtf-subtitle" id="mtfSubtitle"></p>
+                                </div>
+                                <button type="button" class="brc-mtf-close" id="mtfClose" aria-label="Close">&#x2715;</button>
+                            </div>
+                            <div class="brc-mtf-search-wrap">
+                                <input type="text" id="mtfSearch" class="brc-mtf-search" placeholder="Search Folder" autocomplete="off">
+                            </div>
+                            <div class="brc-mtf-list-wrap">
+                                <div class="brc-mtf-list-header">All Videos</div>
+                                <ul class="brc-mtf-list" id="mtfFolderList"></ul>
+                            </div>
+                            <div class="brc-mtf-footer">
+                                <button type="button" class="brc-mtf-btn-cancel" id="mtfCancel">Cancel</button>
+                                <button type="button" class="brc-mtf-btn-move" id="mtfMove" disabled>Move</button>
+                            </div>
+                        </div>
+                    </div>
+
                     <!--Get Upload status-->
                     <div id='getUplStatus' style="display:none" class="overlay">
                         <center>Get Upload Status By VideoId

--- a/current/ui.config/pom.xml
+++ b/current/ui.config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.3</version>
+        <version>7.1.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.content/pom.xml
+++ b/current/ui.content/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.3</version>
+        <version>7.1.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.tests/pom.xml
+++ b/current/ui.tests/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.3</version>
+        <version>7.1.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
- Replace the existing folder dropdown on the bulk action bar with a centred modal dialog matching the provided design specs
- Modal fetches all account folders on open (cached after first load), supports live local search, single-folder selection with toggle, and calls move_video_to_folder for each selected video on confirm
- Overlay uses #1A1A18 at 60 % opacity; scroll is locked while open; folder list scrolls internally when it overflows the modal height
- Bump project version from 7.1.3 to 7.1.4 across all pom.xml files