### PR TITLE
feat(BCON-143): revamp video detail panel

### DIFF
--- a/current/core/src/main/java/com/coresecure/brightcove/wrapper/api/CmsAPI.java
+++ b/current/core/src/main/java/com/coresecure/brightcove/wrapper/api/CmsAPI.java
@@ -337,7 +337,7 @@ public class CmsAPI {
                 LOGGER.info("updateVideoParams: {}", request.toPrettyString());
                 String response = account.platform.patchAPI(targetURL, request.toPrettyString(), headers);
                 if (response != null && !response.isEmpty()) json = JsonReader.readJsonFromString(response);
-            } catch (IOException e) {
+            } catch (Exception e) {
                 LOGGER.error(e.getClass().getName(), e);
             }
         }

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -817,18 +817,16 @@ td.tdMainMenu div {
 }
 
 td.tdMetadata {
-  padding: 0em 1em;
+  padding: 0;
   overflow: auto;
   background-color: #ffffff;
-  border-style: solid;
-  border-left-width: 1px;
-  border-left-color: #000000;
+  border-left: 1px solid #e8e6df;
   height: 100%;
-  color: grey
+  color: #1a1a18;
 }
 
 #tdMeta div {
-  color: black;
+  color: #1a1a18;
 }
 
 thead tr {
@@ -2603,6 +2601,336 @@ body.brc-mtf-open {
 .brc-mtf-btn-move:not([disabled]):hover {
   background: #2a2a26;
   background-color: #2a2a26;
+}
+
+/* ---- BCON-143: Video detail panel ---- */
+.brc-panel {
+  padding: 0;
+  overflow-y: auto;
+  font-family: 'Inter', adobe-clean, Helvetica, Arial, sans-serif;
+  color: #1a1a18;
+  min-width: 220px;
+}
+
+.brc-panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 16px 16px 12px;
+  border-bottom: 1px solid #f0efea;
+}
+
+.brc-panel-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #1a1a18;
+  line-height: 1.4;
+}
+
+.brc-panel-subtitle {
+  font-size: 11px;
+  color: #6b7280;
+  margin-top: 2px;
+}
+
+.brc-panel-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  color: #6b7280;
+  padding: 0;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.brc-panel-section {
+  padding: 14px 16px;
+  border-bottom: 1px solid #f0efea;
+}
+
+.brc-panel-section--last {
+  border-bottom: none;
+}
+
+.brc-panel-section-title {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.77px;
+  text-transform: uppercase;
+  color: #1a1a18;
+  margin-bottom: 12px;
+  font-family: 'Inter', adobe-clean, Helvetica, Arial, sans-serif;
+}
+
+/* Image widgets */
+.brc-panel-images {
+  display: flex;
+  gap: 12px;
+}
+
+.brc-image-widget {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  flex: 1;
+}
+
+.brc-image-preview {
+  width: 100%;
+  aspect-ratio: 16/9;
+  background: #E8E6DE;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  gap: 4px;
+}
+
+.brc-image-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.brc-image-label {
+  font-size: 11px;
+  color: #6b7280;
+}
+
+.brc-image-url-btn {
+  width: 100%;
+  background: #fff;
+  border: 1px solid #e8e6df;
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  color: #1a1a18;
+  cursor: pointer;
+  text-transform: uppercase;
+  font-family: inherit;
+}
+
+.brc-image-url-btn:hover {
+  background: #f7f6f2;
+}
+
+/* Action buttons */
+.brc-panel-action-btn {
+  display: block;
+  width: 100%;
+  background: #fff;
+  border: 1px solid #e8e6df;
+  border-radius: 8px;
+  padding: 9px 14px;
+  font-size: 13px;
+  color: #1a1a18;
+  text-align: center;
+  cursor: pointer;
+  margin-bottom: 8px;
+  font-family: inherit;
+}
+
+.brc-panel-action-btn:last-child {
+  margin-bottom: 0;
+}
+
+.brc-panel-action-btn:hover {
+  background: #f7f6f2;
+}
+
+/* Video info table */
+.brc-panel-info-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.brc-panel-info-table td {
+  padding: 7px 0;
+  border-bottom: 1px solid #f0efea;
+  font-size: 13px;
+  color: #1a1a18;
+  vertical-align: top;
+}
+
+.brc-panel-info-table tr:last-child td {
+  border-bottom: none;
+}
+
+.brc-info-label {
+  font-weight: 500;
+  width: 40%;
+  padding-right: 8px;
+}
+
+/* Variants in panel */
+.brc-variant-link {
+  display: block;
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 13px;
+  color: #1a1a18;
+  text-decoration: none;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  line-height: 1.6;
+}
+
+.brc-variant-link:hover {
+  text-decoration: underline;
+}
+
+/* Label pills */
+.brc-label-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+.brc-label-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: #fff;
+  border: 1px solid #e8e6df;
+  border-radius: 99px;
+  padding: 3px 10px;
+  font-size: 12px;
+  color: #1a1a18;
+}
+
+.brc-label-pill-remove {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-size: 12px;
+  color: #6b7280;
+  line-height: 1;
+}
+
+.brc-label-input {
+  width: 100%;
+  border: 1px solid #e8e6df;
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: 13px;
+  font-family: inherit;
+  color: #1a1a18;
+  box-sizing: border-box;
+}
+
+.brc-label-hint {
+  font-size: 11px;
+  color: #6b7280;
+  margin: 4px 0 10px;
+}
+
+.brc-save-labels-btn {
+  display: block;
+  width: 100%;
+  background: #1a1a18;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 10px 0;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.brc-save-labels-btn:hover {
+  background: #2a2a26;
+}
+
+/* Variant Details modal */
+.brc-variant-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.45);
+  z-index: 9000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.brc-variant-modal[hidden] {
+  display: none;
+}
+
+.brc-variant-modal-dialog {
+  background: #fff;
+  border-radius: 10px;
+  width: 400px;
+  max-width: 90vw;
+  padding: 24px;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.15);
+}
+
+.brc-variant-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.brc-variant-modal-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #1a1a18;
+}
+
+.brc-variant-modal-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  color: #6b7280;
+  padding: 0;
+  line-height: 1;
+}
+
+.brc-variant-section {
+  margin-bottom: 14px;
+}
+
+.brc-variant-field-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.66px;
+  text-transform: uppercase;
+  color: #1a1a18;
+  margin-bottom: 4px;
+  font-family: 'Inter', adobe-clean, Helvetica, Arial, sans-serif;
+}
+
+.brc-variant-section > div:last-child {
+  font-size: 13px;
+  color: #1a1a18;
+}
+
+.brc-variant-cf-table {
+  width: 100%;
+}
+
+.brc-variant-cf-table td {
+  font-size: 13px;
+  color: #1a1a18;
+  padding: 2px 8px 2px 0;
+  vertical-align: top;
+}
+
+.brc-variant-modal-footer {
+  margin-top: 20px;
 }
 
 /* ---------- END NEW CSS --------------- */

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -2606,10 +2606,16 @@ body.brc-mtf-open {
 /* ---- BCON-143: Video detail panel ---- */
 .brc-panel {
   padding: 0;
-  overflow-y: auto;
   font-family: 'Inter', adobe-clean, Helvetica, Arial, sans-serif;
   color: #1a1a18;
   min-width: 220px;
+}
+
+.brc-panel-inner {
+  position: sticky;
+  top: 0;
+  max-height: 100vh;
+  overflow-y: auto;
 }
 
 .brc-panel-header {

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -1522,6 +1522,18 @@ function showMetaDataByVideoID(idx) {
                     document.getElementById('divMeta.text_tracks_table').innerHTML = document.getElementById('divMeta.text_tracks_table').innerHTML + "<tr class='texttrackrow "+defTrack+"'><td class=\"tg-baqh \">" + cur.label + "</td><td  class=\"tg-baqh\">" + cur.srclang + "</td><td  class=\"tg-baqh\">" + cur.kind + "</td><td class=\"tg-baqh delete_button\" onClick=\"deleteTrack('" + cur.id + "','" + v.id + "')\">X</td> </tr>";
                 }
             }
+            $('#divMeta\\.folder').text(v.folder_id ? v.folder_id : 'All Videos');
+
+            _currentLabels = v.labels ? (Array.isArray(v.labels) ? v.labels.slice() : v.labels.toString().split(',').filter(Boolean)) : [];
+            renderLabelPills();
+            $('#labelInput').val('');
+
+            var vidIdx = 0;
+            for (var i = 0; i < oCurrentVideoList.length; i++) {
+                if (String(oCurrentVideoList[i].id) === String(v.id)) { vidIdx = i; break; }
+            }
+            showVariants(v, vidIdx);
+
             $("#tdMeta").show();
         },
         error: function () {
@@ -2244,7 +2256,6 @@ function metaEdit() {
     var sec = String((Math.floor(v.length * .001)) % 60); //The number of seconds not part of a whole minute
     sec.length < 2 ? sec = sec + "0" : sec;  //Make sure  the one's place 0 is included.
 
-    document.getElementById('meta.preview').value = document.getElementById('divMeta.previewDiv').value;
     document.getElementById('meta.length').innerHTML = Math.floor(v.length / 60000) + ":" + sec;
     document.getElementById('tdmeta.id').innerHTML = v.id;
     document.getElementById('meta.id').value = v.id;

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -1419,12 +1419,19 @@ $(document).on('keydown', '#labelInput', function(e) {
 function saveLabels() {
     var videoId = $('#divMeta\\.id').text().trim();
     if (!videoId) return;
+    var savedLabels = _currentLabels.slice();
     $.ajax({
         type: 'GET',
         url: '/bin/brightcove/api.js',
-        data: $.param({ a: 'update_labels', labels: _currentLabels, videoId: videoId }, true),
+        data: $.param({ a: 'update_labels', labels: savedLabels, videoId: videoId }, true),
         async: true,
-        success: function() { brcToast('Labels saved'); }
+        success: function() {
+            var idx = parseInt($('tr.select').attr('id'), 10);
+            if (!isNaN(idx) && oCurrentVideoList[idx]) {
+                oCurrentVideoList[idx].labels = savedLabels;
+            }
+            brcToast('Labels saved');
+        }
     });
 }
 function showMetaDataByVideoID(idx) {

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -100,6 +100,7 @@ var $sortable;
 var brc_admin = brc_admin || {};
 var _mtfAllFolders = [];
 var _mtfSelectedFolderId = null;
+var _currentLabels = [];
 
 
 //tUploadBar has the timer id for the upload progress bar, so it can be cancelled.  progressPos is used to keep track of the progress bar's position.
@@ -482,40 +483,38 @@ $(function () {
         $('body').trigger('brc:checked');
     });
 
-    $('body').on('click', '.variant', function(event) {
-        event.preventDefault();
-        var variantId = $(event.target).attr('data-variant-id');
-        var videoId = $(event.target).attr('data-video-idx');
-        var variant = oCurrentVideoList[videoId].variants[variantId];
+    $('body').on('click', '.brc-variant-link', function() {
+        var variantId = parseInt($(this).attr('data-variant-id'), 10);
+        var videoId   = parseInt($(this).attr('data-video-idx'), 10);
+        var variant   = oCurrentVideoList[videoId].variants[variantId];
 
-        var content = "<div>";
-        content += "<p><strong>Video Name:</strong><br />" + variant.language + "</p>";
+        $('#variantModalTitle').text('Variant Details — ' + variant.language);
+        $('#variantModalName').text(variant.language || '—');
+        $('#variantModalDesc').text(variant.description || '—');
+        $('#variantModalLongDesc').text(variant.long_description || '—');
 
-        if (variant.description)
-            content += "<p><strong>Description:</strong><br />" + variant.description + "</p>";
-
-        if (variant.long_description)
-            content += "<p><strong>Long Description:</strong><br />" + variant.long_description + "</p>";
-
+        var $cf = $('#variantModalCustomFields').empty();
         if (variant.custom_fields && JSON.stringify(variant.custom_fields) !== '{}') {
-            content += "<p><strong>Custom Fields:</strong></p>";
-            for (const prop in variant.custom_fields) {
-                content += "<details open>"
-                content += "<summary>" + prop + "</summary>";
-                content += "<p>" + variant.custom_fields[prop] + "</p>";
-                content += "</details>";
+            var $table = $('<table class="brc-variant-cf-table">');
+            for (var prop in variant.custom_fields) {
+                $table.append(
+                    $('<tr>').append($('<td>').text(prop))
+                             .append($('<td>').text(variant.custom_fields[prop]))
+                );
             }
+            $cf.append($table);
+        } else {
+            $cf.text('—');
         }
 
-        content += "</div>";
+        $('#variantDetailsModal').removeAttr('hidden');
+    });
 
-        showPopup('Variant Details for Language: ' + variant.language,
-                content,
-                'OK',
-                '',
-                function(dialog) {
-                    dialog.hide();
-                });
+    $(document).on('click', '.brc-variant-modal-close, .brc-variant-modal-ok', function() {
+        $('#variantDetailsModal').attr('hidden', '');
+    });
+    $(document).on('click', '#variantDetailsModal', function(e) {
+        if ($(e.target).is('#variantDetailsModal')) $(this).attr('hidden', '');
     });
 
     // Clear search button — Videos
@@ -906,46 +905,6 @@ function loadLabels() {
     });
 }
 
-function editLabels(event) {
-    var data = {
-        videoId: document.getElementById('divMeta.previewDiv').value,
-        items: $(document.getElementById('divMeta.labels')).find('a').map(function() {
-            return $(this).text()
-          })
-          .get()
-    };
-    console.log(data.items);
-    var $search = $('<form autocomplete="off" class="label-add-input"><input type="text" placeholder="Search for a label to add" /><ul class="autocomplete list-unstyled"></ul></form>').prop('outerHTML');
-    var $message = $('<ul class="label-listing list-unstyled" data-label-id="'+data.videoId+'" id="edit-labels-sortable">');
-    data.items.forEach(function(item, index) {
-        $message
-            .append($('<li data-id="'+item+'"><span><span class="handle"></span>'+item+'</span><a href="#" data-label-id="'+item+'"><img src="/apps/brightcove/clientlibs/clientlib-tools/img/shared/img/delete.svg" /></a></li>'));
-    });
-    showPopup('Edit Labels', $search + $message.prop('outerHTML'), 'Update', 'Cancel', function(event) {
-        var playlistData = {
-            a: 'update_labels',
-            labels: $('#edit-labels-sortable')
-                        .find('li')
-                        .map(function(item) { return $(this).text() }).get(),
-            videoId: data.videoId
-        };
-
-        $.ajax({
-            type: 'GET',
-            url: '/bin/brightcove/api.js',
-            data: $.param(playlistData, true),
-            async: true,
-            success: function (data)
-            {
-                location.reload();
-            }
-        });
-
-        event.hide();
-    }, null);
-    var el = document.getElementById("edit-labels-sortable");
-    $sortable = Sortable.create(el);
-}
 
 function callback(data) {
     // generic callback
@@ -1317,103 +1276,97 @@ function showPlaylist() {
 }
 
 function showVariants(v, idx) {
-    if (v) {
-
-        var elVariants = document.getElementById('divMeta.variants');
-
-        // immediately update the text if there are no variants present
-        if (!v.variants) {
-            elVariants.textContent = "No variants.";
-            return;
-        }
-
-        // now we show the variants
-        elVariants.innerHTML = '';
-        for (var x = 0; x < v.variants.length; x++) {
-            var link = '<a href="#" class="variant" data-variant-id="'
-                        + x + '" data-video-idx="' + idx + '">'
-                        + v.variants[x].language + '</a>';
-            elVariants.innerHTML += link;
-        }
+    var $container = $('#divMeta\\.variants').empty();
+    if (!v || !v.variants || v.variants.length === 0) {
+        $container.text('—');
+        return;
     }
+    v.variants.forEach(function(variant, i) {
+        $('<button>')
+            .addClass('brc-variant-link')
+            .attr('data-variant-id', i)
+            .attr('data-video-idx', idx)
+            .text(variant.language)
+            .appendTo($container);
+    });
 }
 
 function showMetaData(idx) {
-
-
-
     $("tr.select").removeClass("select");
     idx = oCurrentVideoList.length > idx ? idx : 0;
     $("#tbData>tr:eq(" + idx + ")").addClass("select");
 
-
-    //CURRENTLY
     var v = oCurrentVideoList[idx];
-
-    console.log(v);
 
     showVariants(v, idx);
 
-    // Populate the metadata panel
+    // Panel header
     document.getElementById('divMeta.name').innerHTML = v.name;
-    document.getElementById('divMeta.thumbnailURL').src = v.thumbnailURL;
-    document.getElementById('divMeta.videoStillURL').src = (v.images != null && v.images.poster != null && v.images.poster.src != null) ? v.images.poster.src : "";
-    document.getElementById('divMeta.previewDiv').value = v.id;
     var modDate = new Date(v.updated_at);
-    document.getElementById('divMeta.lastModifiedDate').innerHTML = (modDate.getMonth() + 1) + "/" + modDate.getDate() + "/" + modDate.getFullYear();
+    document.getElementById('divMeta.lastModifiedDate').innerHTML = 'Updated ' + (modDate.getMonth() + 1) + "/" + modDate.getDate() + "/" + modDate.getFullYear();
 
-    //v.length is the running time of the video in ms
-    var sec = String((Math.floor(v.duration * .001)) % 60); //The number of seconds not part of a whole minute
-    sec.length < 2 ? sec = sec + "0" : sec;  //Make sure  the one's place 0 is included.
+    // Poster preview
+    var $posterPreview = $('#divMeta\\.posterPreview').empty();
+    var posterSrc = (v.images && v.images.poster && v.images.poster.src) ? v.images.poster.src : null;
+    if (posterSrc) {
+        $posterPreview.append($('<img>').attr('src', posterSrc));
+        $('#posterUrlBtn').text('Change URL');
+    } else {
+        $posterPreview.append(_cameraIcon());
+        $('#posterUrlBtn').text('ENTER URL');
+    }
+
+    // Thumbnail preview
+    var $thumbPreview = $('#divMeta\\.thumbPreview').empty();
+    var thumbSrc = v.thumbnailURL || null;
+    if (thumbSrc) {
+        $thumbPreview.append($('<img>').attr('src', thumbSrc));
+        $('#thumbUrlBtn').text('Change URL');
+    } else {
+        $thumbPreview.append(_cameraIcon());
+        $('#thumbUrlBtn').text('ENTER URL');
+    }
+
+    // Duration
+    var sec = String((Math.floor(v.duration * .001)) % 60);
+    sec.length < 2 ? sec = sec + "0" : sec;
     document.getElementById('divMeta.length').innerHTML = Math.floor(v.duration / 60000) + ":" + sec;
 
     document.getElementById('divMeta.id').innerHTML = v.id;
     document.getElementById('divMeta.shortDescription').innerHTML = "<pre style=\"white-space: pre-wrap;\">" + (v.description != null ? v.description : "") + "</pre>";
 
-    //Construct the tag section:
+    // Tags
     var tagsObject = "";
     if ("" != v.tags) {
         var tags = v.tags.toString().split(',');
         for (var k = 0; k < tags.length; k++) {
-            if (k > 0) {
-                tagsObject += ', ';
-            }
+            if (k > 0) tagsObject += ', ';
             tagsObject += '<a style="cursor:pointer;color:blue;text-decoration:underline"' +
                 'onclick="searchVal=\'' + tags[k].replace(/\'/gi, "\\\'") + '\';Load(findByTag(\'' + tags[k] + '\'))" >' + tags[k] + '</a>';
         }
     }
     document.getElementById('divMeta.tags').innerHTML = tagsObject;
 
-    var labelsObject = "";
-    if (v.labels) {
-        var labels = v.labels.toString().split(',');
-        for (var k = 0; k < labels.length; k++) {
-            if (k > 0) {
-                labelsObject += ', ';
-            }
-            labelsObject += '<a href="#" style="cursor:pointer;color:blue;text-decoration:underline"' +
-                'onclick="triggerLabelClick(\'' + labels[k] + '\'); return false;" >' + labels[k] + '</a>';
-        }
-    }
-    document.getElementById('divMeta.labels').innerHTML = labelsObject;
+    // Labels — pill system
+    _currentLabels = v.labels ? (Array.isArray(v.labels) ? v.labels.slice() : v.labels.toString().split(',').filter(Boolean)) : [];
+    renderLabelPills();
+    $('#labelInput').val('');
 
-    //if there's no link text use the linkURL as the text
+    // Link
     var linkText = (v.link != null && "" != v.link.text && null != v.link.text) ? v.link.text : (v.link != null && v.link.url != null) ? v.link.url : "";
     var linkURL = (v.link != null && v.link.url != null) ? v.link.url : "";
     document.getElementById('divMeta.linkURL').innerHTML = linkText;
-
     document.getElementById('divMeta.linkURL').href = linkURL;
     document.getElementById('divMeta.linkText').innerHTML = linkText;
+
     document.getElementById('divMeta.economics').innerHTML = v.economics;
 
     modDate = new Date(v.published_at);
     document.getElementById('divMeta.publishedDate').innerHTML = (modDate.getMonth() + 1) + "/" + modDate.getDate() + "/" + modDate.getFullYear();
     document.getElementById('divMeta.referenceId').innerHTML = (v.reference_id != null) ? v.reference_id : "";
+    $('#divMeta\\.folder').text(v.folder_id ? v.folder_id : 'All Videos');
 
-
-    //document.getElementById('divMeta.text_tracks').innerHTML = "<button>" +  v.toString() + "</button>";
-
-
+    // Text tracks
     $ACTIVE_TRACKS = v.text_tracks != null ? v.text_tracks : "";
     var arr = v.text_tracks != null ? v.text_tracks : "";
     document.getElementById('divMeta.text_tracks').innerHTML = "";
@@ -1423,13 +1376,56 @@ function showMetaData(idx) {
         document.getElementById('divMeta.text_tracks').innerHTML = tableTmpl;
         for (var x = 0; x < arr.length; x++) {
             var cur = arr[x];
-            var defTrack = "";
-            if (cur["default"]) {
-                defTrack = "default_track";
-            }
-            document.getElementById('divMeta.text_tracks_table').innerHTML = document.getElementById('divMeta.text_tracks_table').innerHTML + "<tr class='texttrackrow "+defTrack+"'><td class=\"tg-baqh \">" + cur.label + "</td><td  class=\"tg-baqh\">" + cur.srclang + "</td><td  class=\"tg-baqh\">" + cur.kind + "</td><td class=\"tg-baqh delete_button\" onClick=\"deleteTrack('" + cur.id + "','" + v.id + "')\">X</td> </tr>";
+            var defTrack = cur["default"] ? "default_track" : "";
+            document.getElementById('divMeta.text_tracks_table').innerHTML += "<tr class='texttrackrow " + defTrack + "'><td class=\"tg-baqh \">" + cur.label + "</td><td class=\"tg-baqh\">" + cur.srclang + "</td><td class=\"tg-baqh\">" + cur.kind + "</td><td class=\"tg-baqh delete_button\" onClick=\"deleteTrack('" + cur.id + "','" + v.id + "')\">X</td></tr>";
         }
     }
+}
+
+function _cameraIcon() {
+    return $('<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">' +
+        '<path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" stroke="#6b7280" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>' +
+        '<circle cx="12" cy="13" r="4" stroke="#6b7280" stroke-width="2"/>' +
+        '</svg>');
+}
+
+function renderLabelPills() {
+    var $container = $('#divMeta\\.labels').empty();
+    _currentLabels.forEach(function(label) {
+        var $pill = $('<span class="brc-label-pill">')
+            .append($('<span>').text(label))
+            .append(
+                $('<button class="brc-label-pill-remove" type="button" aria-label="Remove">').text('×')
+                    .on('click', function() {
+                        var i = _currentLabels.indexOf(label);
+                        if (i > -1) _currentLabels.splice(i, 1);
+                        $(this).closest('.brc-label-pill').remove();
+                    })
+            );
+        $container.append($pill);
+    });
+}
+
+$(document).on('keydown', '#labelInput', function(e) {
+    if (e.key !== 'Enter') return;
+    e.preventDefault();
+    var val = $(this).val().trim();
+    if (!val || _currentLabels.indexOf(val) > -1) return;
+    _currentLabels.push(val);
+    renderLabelPills();
+    $(this).val('');
+});
+
+function saveLabels() {
+    var videoId = $('#divMeta\\.id').text().trim();
+    if (!videoId) return;
+    $.ajax({
+        type: 'GET',
+        url: '/bin/brightcove/api.js',
+        data: $.param({ a: 'update_labels', labels: _currentLabels, videoId: videoId }, true),
+        async: true,
+        success: function() { brcToast('Labels saved'); }
+    });
 }
 function showMetaDataByVideoID(idx) {
 
@@ -1449,11 +1445,20 @@ function showMetaDataByVideoID(idx) {
 
             // Populate the metadata panel
             document.getElementById('divMeta.name').innerHTML = v.name;
-            document.getElementById('divMeta.thumbnailURL').src = (v.images != null && v.images.thumbnail != null && v.images.thumbnail.src != null) ? v.images.thumbnail.src : "";
-            document.getElementById('divMeta.videoStillURL').src = (v.images != null && v.images.poster != null && v.images.poster.src != null) ? v.images.poster.src : "";
-            document.getElementById('divMeta.previewDiv').value = v.id;
             var modDate = new Date(v.updated_at);
-            document.getElementById('divMeta.lastModifiedDate').innerHTML = (modDate.getMonth() + 1) + "/" + modDate.getDate() + "/" + modDate.getFullYear();
+            document.getElementById('divMeta.lastModifiedDate').innerHTML = 'Updated ' + (modDate.getMonth() + 1) + "/" + modDate.getDate() + "/" + modDate.getFullYear();
+
+            // Poster preview
+            var $posterPreview = $('#divMeta\\.posterPreview').empty();
+            var posterSrc = (v.images && v.images.poster && v.images.poster.src) ? v.images.poster.src : null;
+            if (posterSrc) { $posterPreview.append($('<img>').attr('src', posterSrc)); $('#posterUrlBtn').text('Change URL'); }
+            else { $posterPreview.append(_cameraIcon()); $('#posterUrlBtn').text('ENTER URL'); }
+
+            // Thumbnail preview
+            var $thumbPreview = $('#divMeta\\.thumbPreview').empty();
+            var thumbSrc = (v.images && v.images.thumbnail && v.images.thumbnail.src) ? v.images.thumbnail.src : null;
+            if (thumbSrc) { $thumbPreview.append($('<img>').attr('src', thumbSrc)); $('#thumbUrlBtn').text('Change URL'); }
+            else { $thumbPreview.append(_cameraIcon()); $('#thumbUrlBtn').text('ENTER URL'); }
 
             //v.length is the running time of the video in ms
             var sec = String((Math.floor(v.duration * .001)) % 60); //The number of seconds not part of a whole minute
@@ -1623,7 +1628,7 @@ function uploadPoster()
           '<div class="coral-Form-fieldwrapper">' +
           '<label class="coral-Form-fieldlabel" id="label-vertical-textfield-0">Poster Source URL</label>' +
           '<input is="coral-textfield" class="coral-Form-field" placeholder="https://" name="name" id="upload_poster_dialog_field_source" labelledby="label-vertical-textfield-0"' +
-          'value="' + document.getElementById('divMeta.videoStillURL').src + '"' +
+          'value="' + ($('#divMeta\\.posterPreview img').attr('src') || '') + '"' +
           '></div></form>'
         },
         footer: {
@@ -1645,11 +1650,12 @@ function uploadPoster()
                 url: apiLocation + '.js',
                 type: 'POST',
                 data: fields,
-                success: function ( data ){
-                    window.selectedVideoId = document.getElementById('divMeta.id').innerHTML;
-                    Load(getAllVideosURL());
+                success: function () {
+                    var url = $('#upload_poster_dialog_field_source').val();
+                    $('#divMeta\\.posterPreview').empty().append($('<img>').attr('src', url));
+                    $('#posterUrlBtn').text('Change URL');
                     dialog.hide();
-                    location.reload();
+                    brcToast('Poster updated');
                 },
                 error: function ( data )
                 {
@@ -1685,7 +1691,7 @@ function uploadThumbnail()
           '<div class="coral-Form-fieldwrapper">' +
           '<label class="coral-Form-fieldlabel" id="label-vertical-textfield-0">Thumbnail Source URL</label>' +
           '<input is="coral-textfield" class="coral-Form-field" placeholder="https://" name="name" id="upload_thumbnail_dialog_field_source" labelledby="label-vertical-textfield-0"' +
-          'value="' + document.getElementById('divMeta.thumbnailURL').src + '"' +
+          'value="' + ($('#divMeta\\.thumbPreview img').attr('src') || '') + '"' +
           '></div></form>'
         },
         footer: {
@@ -1707,11 +1713,12 @@ function uploadThumbnail()
                 url: apiLocation + '.js',
                 type: 'POST',
                 data: fields,
-                success: function ( data ){
-                    window.selectedVideoId = document.getElementById('divMeta.id').innerHTML;
-                    Load(getAllVideosURL());
+                success: function () {
+                    var url = $('#upload_thumbnail_dialog_field_source').val();
+                    $('#divMeta\\.thumbPreview').empty().append($('<img>').attr('src', url));
+                    $('#thumbUrlBtn').text('Change URL');
                     dialog.hide();
-                    location.reload();
+                    brcToast('Thumbnail updated');
                 },
                 error: function ( data )
                 {

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
@@ -252,78 +252,70 @@
 
                             <!-- start right metadata column, fields filled in by showMetaData() -->
                             <!--Element Id's have the meta. prefix followed by the actual name of the Video object field.  This allows the fields to be easily compared.  See  metaSubmit()  -->
-                            <td id="tdMeta" valign="top" class="tdMetadata" style="display:none;">
-                                <br/>
-                                <span type="button" title="hide metadata" style="float:right;cursor: pointer;" onclick="closeBox('tdMeta')">x</span>
-                                <div id="divMeta.name" style="font-weight:bold"></div>
-                                <br/>Last Updated:
-                                <div id="divMeta.lastModifiedDate"></div>
-                                <hr/>
-                                <div id="divMeta.previewDiv">
-                                    <ul class="thumbnails list-unstyled">
-                                        <li class="span3">
-                                            <div class="thumbnail">
-                                                <img id="divMeta.videoStillURL" alt=" No Image " style="width:260px"/>
-                                                <a onClick="uploadPoster()" href="#"
-                                                   class="btn">Change Poster</a>
-                                            </div>
-                                        </li>
-                                        <li class="span2">
-                                            <div class="thumbnail">
-                                                <img id="divMeta.thumbnailURL" alt=" No Thumbnail " style="width:160px"/>
-                                                <a onClick="uploadThumbnail()" href="#"
-                                                   class="btn">Change Thumbnail</a>
-                                            </div>
-                                        </li>
+                            <td id="tdMeta" valign="top" class="tdMetadata brc-panel" style="display:none;">
 
-                                    </ul>
-
-                                    <!--Upload text track / Delete Track-->
-                                    <center id="trackarea">
-                                        <!--<span>Click Below to Remove Text Track</span><br>-->
-                                        <div id="divMeta.text_tracks">
-                                        </div>
-                                        <br/>
-                                        <button id="uploadtrackbutton" onClick="uploadtrack()" style="display:block">Upload New Text Track</button>
-                                        <br/>
-
-                                    </center>
-                                    <p><a href="#" onClick="doPreview(document.getElementById('divMeta.id').innerHTML)"
-                                          class="btn btn-primary btn-block">Video Preview</a>
-                                    </p>
+                                <!-- Panel header -->
+                                <div class="brc-panel-header">
+                                    <div>
+                                        <div class="brc-panel-title" id="divMeta.name"></div>
+                                        <div class="brc-panel-subtitle" id="divMeta.lastModifiedDate"></div>
+                                    </div>
+                                    <button class="brc-panel-close" type="button" onclick="closeBox('tdMeta')" aria-label="Close">&#x2715;</button>
                                 </div>
-                                <br/>Variants:
-                                <div id="divMeta.variants">N/A</div>
-                                <br/>Duration:
-                                <div id="divMeta.length"></div>
-                                <br/>Video ID:
-                                <div id="divMeta.id"></div>
-                                <br/>
-                                <hr>
-                                Short Description:
-                                <div id="divMeta.shortDescription"></div>
-                                <br/>Tags:
-                                <div id="divMeta.tags"></div>
-                                <br/>
-                                <span class="hdr-labels">
-                                    <span>Labels:</span>
-                                    <a href="#" onclick="editLabels(this); return false;">Edit</a>
-                                </span>
-                                <div id="divMeta.labels"></div>
-                                <br/>Related Link:
-                                <br/>
-                                <a id="divMeta.linkURL"></a>
-                                <br/>
-                                <br/>
 
-                                <div style="display:none" id="divMeta.linkText"></div>
-                                Economics:
-                                <div id="divMeta.economics"></div>
-                                <br/>Date Published:
-                                <div id="divMeta.publishedDate"></div>
-                                <br/>Reference ID:
-                                <div id="divMeta.referenceId"></div>
-                                <br/>
+                                <!-- IMAGES -->
+                                <div class="brc-panel-section">
+                                    <div class="brc-panel-section-title">IMAGES</div>
+                                    <div class="brc-panel-images">
+                                        <div class="brc-image-widget">
+                                            <div class="brc-image-preview" id="divMeta.posterPreview"></div>
+                                            <span class="brc-image-label">Poster</span>
+                                            <button class="brc-image-url-btn" id="posterUrlBtn" type="button" onclick="uploadPoster()">ENTER URL</button>
+                                        </div>
+                                        <div class="brc-image-widget">
+                                            <div class="brc-image-preview" id="divMeta.thumbPreview"></div>
+                                            <span class="brc-image-label">Thumbnail</span>
+                                            <button class="brc-image-url-btn" id="thumbUrlBtn" type="button" onclick="uploadThumbnail()">ENTER URL</button>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <!-- ACTIONS -->
+                                <div class="brc-panel-section" id="trackarea">
+                                    <div class="brc-panel-section-title">ACTIONS</div>
+                                    <div id="divMeta.text_tracks"></div>
+                                    <button class="brc-panel-action-btn" type="button" onclick="uploadtrack()">Upload New Text Track</button>
+                                    <button class="brc-panel-action-btn" type="button"
+                                            onclick="doPreview(document.getElementById('divMeta.id').innerHTML)">Video Preview</button>
+                                </div>
+
+                                <!-- VIDEO INFO -->
+                                <div class="brc-panel-section">
+                                    <div class="brc-panel-section-title">VIDEO INFO</div>
+                                    <table class="brc-panel-info-table">
+                                        <tr><td class="brc-info-label">Video ID</td><td id="divMeta.id"></td></tr>
+                                        <tr><td class="brc-info-label">Duration</td><td id="divMeta.length"></td></tr>
+                                        <tr><td class="brc-info-label">Variants</td><td id="divMeta.variants"></td></tr>
+                                        <tr><td class="brc-info-label">Published</td><td id="divMeta.publishedDate"></td></tr>
+                                        <tr><td class="brc-info-label">Economics</td><td id="divMeta.economics"></td></tr>
+                                        <tr><td class="brc-info-label">Reference ID</td><td id="divMeta.referenceId"></td></tr>
+                                        <tr><td class="brc-info-label">Folder</td><td id="divMeta.folder"></td></tr>
+                                        <tr><td class="brc-info-label">Short Description</td><td id="divMeta.shortDescription"></td></tr>
+                                        <tr><td class="brc-info-label">Tags</td><td id="divMeta.tags"></td></tr>
+                                        <tr><td class="brc-info-label">Related Link</td><td><a id="divMeta.linkURL"></a></td></tr>
+                                    </table>
+                                    <div style="display:none" id="divMeta.linkText"></div>
+                                </div>
+
+                                <!-- LABELS -->
+                                <div class="brc-panel-section brc-panel-section--last">
+                                    <div class="brc-panel-section-title">LABELS</div>
+                                    <div id="divMeta.labels" class="brc-label-pills"></div>
+                                    <input type="text" id="labelInput" class="brc-label-input" placeholder="Add label..." autocomplete="off">
+                                    <div class="brc-label-hint">Press Enter to add a label</div>
+                                    <button id="saveLabelsBtn" type="button" class="brc-save-labels-btn" onclick="saveLabels()">Save Labels</button>
+                                </div>
+
                             </td>
                         </tr>
                     </table>
@@ -614,6 +606,37 @@
                     </svg>-->
                 </div>
             </div>
+        <!-- Variant Details modal (BCON-143) -->
+        <div id="variantDetailsModal" class="brc-variant-modal" hidden>
+            <div class="brc-variant-modal-dialog">
+                <div class="brc-variant-modal-header">
+                    <span id="variantModalTitle" class="brc-variant-modal-title"></span>
+                    <button class="brc-variant-modal-close" type="button" aria-label="Close">&#x2715;</button>
+                </div>
+                <div class="brc-variant-modal-body">
+                    <div class="brc-variant-section">
+                        <div class="brc-variant-field-label">VIDEO NAME</div>
+                        <div id="variantModalName"></div>
+                    </div>
+                    <div class="brc-variant-section">
+                        <div class="brc-variant-field-label">DESCRIPTION</div>
+                        <div id="variantModalDesc"></div>
+                    </div>
+                    <div class="brc-variant-section">
+                        <div class="brc-variant-field-label">LONG DESCRIPTION</div>
+                        <div id="variantModalLongDesc"></div>
+                    </div>
+                    <div class="brc-variant-section">
+                        <div class="brc-variant-field-label">CUSTOM FIELDS</div>
+                        <div id="variantModalCustomFields"></div>
+                    </div>
+                </div>
+                <div class="brc-variant-modal-footer">
+                    <button type="button" class="brc-save-labels-btn brc-variant-modal-ok">OK</button>
+                </div>
+            </div>
+        </div>
+
         </body>
     </sly>
 </html>

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
@@ -253,6 +253,7 @@
                             <!-- start right metadata column, fields filled in by showMetaData() -->
                             <!--Element Id's have the meta. prefix followed by the actual name of the Video object field.  This allows the fields to be easily compared.  See  metaSubmit()  -->
                             <td id="tdMeta" valign="top" class="tdMetadata brc-panel" style="display:none;">
+                                <div class="brc-panel-inner">
 
                                 <!-- Panel header -->
                                 <div class="brc-panel-header">
@@ -315,6 +316,7 @@
                                     <div class="brc-label-hint">Press Enter to add a label</div>
                                     <button id="saveLabelsBtn" type="button" class="brc-save-labels-btn" onclick="saveLabels()">Save Labels</button>
                                 </div>
+                                </div><!-- /.brc-panel-inner -->
 
                             </td>
                         </tr>


### PR DESCRIPTION
## Summary

- Replaces the legacy `#tdMeta` panel with a structured section layout (IMAGES, ACTIONS, VIDEO INFO, LABELS) matching the Figma design (frames C `93:2`, D `93:125`, I `95:20`)
- Poster and Thumbnail widgets: tan `#E8E6DE` background, camera icon when no URL, in-place DOM update on URL save (no page reload), "Change URL" button state
- Variant language codes rendered as plain black non-underlined buttons; clicking opens a new Variant Details modal with VIDEO NAME, DESCRIPTION, LONG DESCRIPTION, CUSTOM FIELDS sections
- Labels section: white pill UI with inline × remove, Enter-to-add input, "Save Labels" black filled button with toast confirmation; in-memory `oCurrentVideoList` updated on successful save so pills persist across panel close/reopen within the same session
- Panel content wrapped in a sticky scrollable div so the LABELS section is reachable at any viewport height without losing the panel's right-column position
- `CmsAPI.updateLabels`: widened `catch (IOException e)` to `catch (Exception e)` to prevent `ClassCastException` (thrown when Brightcove returns an error array) from propagating to AEM's 500 handler

## Known gaps / follow-ups

- **Labels feature flag**: Brightcove labels must be enabled per-account by Brightcove Support. The connector endpoints (`create_label`, `update_labels`, `list_labels`) are fully implemented and will work once the flag is on for the account.
- **Folder name**: VIDEO INFO shows `folder_id` UUID when a video is in a folder; human-readable name lookup requires a separate join against the folder list and is left as a future improvement.
- **Short Description / Tags / Related Link rows**: kept in VIDEO INFO (not in Figma design) pending design review decision to remove them.

## Test plan

- [x] Panel opens on video row click; X closes it
- [x] Section labels (IMAGES, ACTIONS, VIDEO INFO, LABELS) render in black uppercase
- [x] VIDEO INFO field labels and values render in black
- [x] Poster and Thumbnail widgets use tan background; camera icon when no URL
- [x] After URL entered and saved, widget updates in-place with image and "Change URL"
- [x] Variant language codes are black, non-underlined; clicking opens Variant Details modal
- [x] Variant Details modal shows VIDEO NAME, DESCRIPTION, LONG DESCRIPTION, CUSTOM FIELDS in black text; X and OK both close it
- [x] Labels render as white pills with × remove; Enter adds a new pill; Save Labels shows toast
- [x] Panel scrolls so LABELS section is reachable at 900px viewport height
- [x] Filter panel (frame D) coexists with detail panel without layout breakage