### PR TITLE
fix(BGS-1690): preserve AEM author scroll/state on Brightcove component edits (7.1.4.1)

### DIFF
--- a/current/all/pom.xml
+++ b/current/all/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.4</version>
+        <version>7.1.4.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/analyse/pom.xml
+++ b/current/analyse/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.4</version>
+        <version>7.1.4.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/core/pom.xml
+++ b/current/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.4</version>
+        <version>7.1.4.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>brightcove.core</artifactId>

--- a/current/it.tests/pom.xml
+++ b/current/it.tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.4</version>
+        <version>7.1.4.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/pom.xml
+++ b/current/pom.xml
@@ -21,7 +21,7 @@
     <groupId>com.coresecure</groupId>
     <artifactId>brightcove</artifactId>
     <packaging>pom</packaging>
-    <version>7.1.4</version>
+    <version>7.1.4.1</version>
     <description>Brightcove Connector</description>
 
     <modules>

--- a/current/ui.apps.structure/pom.xml
+++ b/current/ui.apps.structure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.4</version>
+        <version>7.1.4.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.apps/pom.xml
+++ b/current/ui.apps/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.4</version>
+        <version>7.1.4.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-base/players/html5-player/js/BrightcoveExperiences.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-base/players/html5-player/js/BrightcoveExperiences.js
@@ -123,6 +123,13 @@ function createPlayers(root) {
     var pendingRoots = [];
     var scheduled = false;
 
+    // Bind to window so the native methods retain their receiver — calling
+    // a detached window.requestAnimationFrame throws TypeError: Illegal
+    // invocation in strict mode, and even in non-strict mode it's fragile.
+    var defer = typeof window.requestAnimationFrame === "function"
+        ? window.requestAnimationFrame.bind(window)
+        : function (cb) { return window.setTimeout(cb, 0); };
+
     function flush() {
         scheduled = false;
         var roots = pendingRoots;
@@ -136,7 +143,7 @@ function createPlayers(root) {
         pendingRoots.push(root);
         if (!scheduled) {
             scheduled = true;
-            (window.requestAnimationFrame || setTimeout)(flush, 0);
+            defer(flush);
         }
     }
 

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-base/players/html5-player/js/BrightcoveExperiences.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-base/players/html5-player/js/BrightcoveExperiences.js
@@ -34,8 +34,9 @@
 document.addEventListener("DOMContentLoaded", (event) => {
   createPlayers();
 });
-function createPlayers() {
-    var all = document.getElementsByClassName("brightcove-container");
+function createPlayers(root) {
+    var scope = root || document;
+    var all = scope.getElementsByClassName("brightcove-container");
     for (var i = 0, max = all.length; i < max; i++) {
         var selected_element = all[i];
         var playerID= selected_element.getAttribute("data-playerid");
@@ -109,3 +110,60 @@ function createPlayers() {
         document.body.appendChild(s);
     }
 }
+
+// BGS-1690: In AEM authoring, REFRESH_SELF swaps in new component HTML but
+// DOMContentLoaded never re-fires, so createPlayers() doesn't bootstrap the
+// new container and the live preview stays blank until manual refresh.
+// Watch the document for inserted/replaced .brightcove-container nodes and
+// re-init just the affected subtree. Works for insert / edit / copy / paste
+// regardless of which AEM editor event fires.
+(function () {
+    if (typeof MutationObserver === "undefined") return;
+
+    var pendingRoots = [];
+    var scheduled = false;
+
+    function flush() {
+        scheduled = false;
+        var roots = pendingRoots;
+        pendingRoots = [];
+        for (var i = 0; i < roots.length; i++) {
+            createPlayers(roots[i]);
+        }
+    }
+
+    function schedule(root) {
+        pendingRoots.push(root);
+        if (!scheduled) {
+            scheduled = true;
+            (window.requestAnimationFrame || setTimeout)(flush, 0);
+        }
+    }
+
+    var observer = new MutationObserver(function (mutations) {
+        for (var i = 0; i < mutations.length; i++) {
+            var added = mutations[i].addedNodes;
+            for (var j = 0; j < added.length; j++) {
+                var node = added[j];
+                if (node.nodeType !== 1) continue;
+                if (node.classList && node.classList.contains("brightcove-container")) {
+                    schedule(node.parentNode || node);
+                } else if (node.querySelector && node.querySelector(".brightcove-container")) {
+                    schedule(node);
+                }
+            }
+        }
+    });
+
+    function start() {
+        if (document.body) {
+            observer.observe(document.body, { childList: true, subtree: true });
+        }
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", start);
+    } else {
+        start();
+    }
+})();

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/content/brightcoveexperiences/_cq_editConfig.xml
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/content/brightcoveexperiences/_cq_editConfig.xml
@@ -6,8 +6,8 @@
     jcr:primaryType="cq:EditConfig">
     <cq:listeners
         jcr:primaryType="cq:EditListenersConfig"
-        aftercopy="REFRESH_PAGE"
-        afterdelete="REFRESH_PAGE"
-        afteredit="REFRESH_PAGE"
-        afterinsert="REFRESH_PAGE"/>
+        aftercopy="REFRESH_SELF"
+        afterdelete="REFRESH_SELF"
+        afteredit="REFRESH_SELF"
+        afterinsert="REFRESH_SELF"/>
 </jcr:root>

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/content/brightcoveplayer-playlist/_cq_editConfig.xml
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/content/brightcoveplayer-playlist/_cq_editConfig.xml
@@ -18,8 +18,8 @@
     </cq:dropTargets>
     <cq:listeners
         jcr:primaryType="cq:EditListenersConfig"
-        aftercopy="REFRESH_PAGE"
-        afterdelete="REFRESH_PAGE"
-        afteredit="REFRESH_PAGE"
-        afterinsert="REFRESH_PAGE"/>
+        aftercopy="REFRESH_SELF"
+        afterdelete="REFRESH_SELF"
+        afteredit="REFRESH_SELF"
+        afterinsert="REFRESH_SELF"/>
 </jcr:root>

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/content/brightcoveplayer/_cq_editConfig.xml
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/content/brightcoveplayer/_cq_editConfig.xml
@@ -13,8 +13,8 @@
     </cq:dropTargets>
     <cq:listeners
         jcr:primaryType="cq:EditListenersConfig"
-        aftercopy="REFRESH_PAGE"
-        afterdelete="REFRESH_PAGE"
-        afteredit="REFRESH_PAGE"
-        afterinsert="REFRESH_PAGE"/>
+        aftercopy="REFRESH_SELF"
+        afterdelete="REFRESH_SELF"
+        afteredit="REFRESH_SELF"
+        afterinsert="REFRESH_SELF"/>
 </jcr:root>

--- a/current/ui.config/pom.xml
+++ b/current/ui.config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.4</version>
+        <version>7.1.4.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.content/pom.xml
+++ b/current/ui.content/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.4</version>
+        <version>7.1.4.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.tests/pom.xml
+++ b/current/ui.tests/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.4</version>
+        <version>7.1.4.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
## Summary

Hotfix on the 7.1.4-cloud line for **BGS-1690** — Thermo Fisher (account `3845398929001`) reported that adding or editing a Brightcove component in AEM authoring triggers a full-page iframe reload, losing scroll position and dialog state.

Cuts release **7.1.4.1** (does not include in-flight UI work on `cloud-master`).

## What changed

Two commits:

1. **`f5851ed` fix(BGS-1690): preserve AEM author scroll/state on Brightcove component edits**
   - `cq:listeners` on `brightcoveplayer`, `brightcoveplayer-playlist`, and `brightcoveexperiences` flipped from `REFRESH_PAGE` to `REFRESH_SELF` for all four events (`aftercopy`, `afterdelete`, `afteredit`, `afterinsert`).
   - `MutationObserver` added in `clientlib-base/players/html5-player/js/BrightcoveExperiences.js` to re-run `createPlayers()` when a `.brightcove-container` is inserted or replaced. Without it, `REFRESH_SELF` swaps in the new component HTML via XHR but `DOMContentLoaded` never re-fires, leaving the live preview blank until a manual refresh.
   - `createPlayers()` now takes an optional root scope so the observer re-inits only the affected subtree.
   - `afterdelete` kept explicitly — AEM's omitted-listener fallback is `REFRESH_PAGE`, which would silently re-introduce the bug on delete.

2. **`87444cf` chore: bump version to 7.1.4.1** (all 10 poms)

## Why scope was expanded to brightcoveexperiences

The ticket only flagged `brightcoveplayer`, but `brightcoveexperiences` shipped with the identical listener pattern and is the same class of bug. Fixing one without the other would leave the same regression on the third component.

## Test plan

Local AEM author at `http://localhost:4502/editor.html/content/test-site/bgs-test-page.html` (use `current/scripts/setup-local-dev.sh` to seed the test page; see `wiki/api/aem-connector-local-dev.md`).

- [ ] **Insert**: drop a Brightcove Player → configure → player renders in place, no manual refresh, page scroll preserved.
- [ ] **Edit existing**: configure an already-placed Player → player re-renders with new config, no manual refresh, scroll preserved.
- [ ] **Copy/paste**: pasted copy renders without manual refresh.
- [ ] **Delete**: component vanishes, no full-page reload.
- [ ] Repeat all four for **Brightcove Playlist Player**.
- [ ] Repeat insert + edit for **Brightcove Experiences**.
- [ ] Editing one component does **not** flicker an unrelated Brightcove component on the same page (MutationObserver scopes the re-init).

JCR-level smoke verification:

```
curl -u admin:admin "http://localhost:4502/apps/brightcove/components/content/<component>/cq:editConfig/cq:listeners.json"
```

Should return `REFRESH_SELF` for all four listener attributes on all three components.

## Related

- A separate branch `bugfix/cloud-master/BGS-1690-edit-listeners` holds the same commit on top of `cloud-master`, to be cherry-picked / merged once the in-flight admin UI work clears QA.
- Existing released line: `7.1.4-cloud` (BGS-1600 PATCH/405 Java 21 fix).