### PR TITLE
fix(BGS-1600): sync Brightcove folder on the publish path (7.1.4.2)

### DIFF
--- a/current/all/pom.xml
+++ b/current/all/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.4.1</version>
+        <version>7.1.4.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/analyse/pom.xml
+++ b/current/analyse/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.4.1</version>
+        <version>7.1.4.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/core/pom.xml
+++ b/current/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.4.1</version>
+        <version>7.1.4.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>brightcove.core</artifactId>

--- a/current/core/src/main/java/com/coresecure/brightcove/wrapper/listeners/BrightcovePublishListener.java
+++ b/current/core/src/main/java/com/coresecure/brightcove/wrapper/listeners/BrightcovePublishListener.java
@@ -18,8 +18,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import java.io.InputStream;
+import java.util.concurrent.TimeUnit;
 
 import com.coresecure.brightcove.wrapper.sling.ConfigurationGrabber;
 import com.coresecure.brightcove.wrapper.sling.ConfigurationService;
@@ -96,6 +98,13 @@ public class BrightcovePublishListener implements EventHandler {
                 LOG.trace("UPDATING RENDITIONS FOR THIS ASSET");
                 serviceUtil.updateRenditions(_asset, video);
 
+                // BGS-1600: move the new video into the Brightcove folder that mirrors
+                // its AEM parent folder. Without this the publish path leaves the video
+                // in the default "All Videos" folder (the workflow/sync-button path has
+                // always done this; the publish listener never did).
+                Node assetNode = _asset.adaptTo(Node.class);
+                syncFolder(serviceUtil, api_resp, assetNode);
+
                 LOG.info("BC: ACTIVATION SUCCESSFUL >> {}", _asset.getPath());
 
                 // update the metadata to show the last sync time
@@ -135,6 +144,11 @@ public class BrightcovePublishListener implements EventHandler {
                 LOG.info("Brightcove video updated successfully: {}", _asset.getPath());
                 serviceUtil.updateRenditions(_asset, video);
                 LOG.info("Updated renditions for Brightcove video: {}", _asset.getPath());
+
+                // BGS-1600: keep the Brightcove folder in sync with the AEM parent folder
+                // on re-publish as well, mirroring the workflow/sync-button path.
+                Node assetNode = _asset.adaptTo(Node.class);
+                syncFolder(serviceUtil, api_resp, assetNode);
 
                 long current_time_millisec = new Date().getTime();
                 brc_lastsync_map.put(Constants.BRC_LASTSYNC, current_time_millisec);
@@ -198,6 +212,76 @@ public class BrightcovePublishListener implements EventHandler {
 
         }
 
+    }
+
+    private void syncFolder(ServiceUtil serviceUtil, ObjectNode api_resp, Node assetNode) {
+        try {
+            LOG.trace("CHECKING PARENT FOR BRC_FOLDER_ID: " + assetNode.getParent().getPath());
+            Node parentNode = assetNode.getParent();
+            String videoId = api_resp.get(Constants.VIDEOID).asText();
+
+            // Skip folder sync if the asset lives directly in the account root folder.
+            // The account root (e.g. /content/dam/brightcove_assets/{accountId}) has no
+            // brc_folder_id, so without this guard syncFolder would create a spurious
+            // Brightcove folder named after the account ID and move the video into it.
+            ConfigurationGrabber cg = ServiceUtil.getConfigurationGrabber();
+            for (String accountId : cg.getAvailableServices()) {
+                ConfigurationService cs = cg.getConfigurationService(accountId);
+                if (cs == null) continue;
+                String integrationPath = cs.getAssetIntegrationPath();
+                String normalized = integrationPath.endsWith("/")
+                        ? integrationPath.substring(0, integrationPath.length() - 1)
+                        : integrationPath;
+                String accountRootPath = normalized + "/" + accountId;
+                if (parentNode.getPath().equals(accountRootPath)) {
+                    LOG.info("Asset is at account root level ({}), skipping Brightcove folder sync", accountRootPath);
+                    return;
+                }
+            }
+
+            if (!parentNode.hasProperty("brc_folder_id")) {
+                String folderId = serviceUtil.createFolder(assetNode.getParent().getName());
+                if (folderId != null && !folderId.isEmpty()) {
+                    setFolderIdMoveAssetInBC(serviceUtil, parentNode, videoId, folderId);
+                } else {
+                    LOG.error("*************************** No folder created ***************************");
+                    TimeUnit.SECONDS.sleep(15);
+                    parentNode.refresh(false);
+                    if (!parentNode.hasProperty("brc_folder_id")) {
+                        folderId = serviceUtil.createFolder(assetNode.getParent().getName());
+                        if (folderId != null && !folderId.isEmpty()) {
+                            setFolderIdMoveAssetInBC(serviceUtil, parentNode, videoId, folderId);
+                        } else {
+                            LOG.error("*************************** No folder created attempt 2 ***************************");
+                        }
+                    } else {
+                        // this is in a subfolder so we need to formally move the asset to this folder
+                        String brc_folder_id = parentNode.getProperty("brc_folder_id").getString();
+                        LOG.trace("SUBFOLDER FOUND - SETTING THE FOLDER ID to '" + brc_folder_id + "'");
+                        serviceUtil.moveVideoToFolder(brc_folder_id, videoId);
+                    }
+                }
+            } else {
+                // this is in a subfolder so we need to formally move the asset to this folder
+                String brc_folder_id = parentNode.getProperty("brc_folder_id").getString();
+                LOG.trace("SUBFOLDER FOUND - SETTING THE FOLDER ID to '" + brc_folder_id + "'");
+                serviceUtil.moveVideoToFolder(brc_folder_id, videoId);
+            }
+
+        } catch (Exception e) {
+
+            // log the error
+            LOG.error("Error syncing folder");
+
+        }
+    }
+
+    private void setFolderIdMoveAssetInBC(ServiceUtil serviceUtil, Node parentNode, String videoId, String folderId) throws Exception {
+        parentNode.setProperty("brc_folder_id", folderId);
+        parentNode.getSession().save();
+
+        LOG.trace("SUBFOLDER FOUND - SETTING THE FOLDER ID to '" + folderId + "'");
+        serviceUtil.moveVideoToFolder(folderId, videoId);
     }
 
     private void deactivateAsset(ResourceResolver rr, Asset _asset, String accountId) {

--- a/current/core/src/main/java/com/coresecure/brightcove/wrapper/listeners/BrightcovePublishListener.java
+++ b/current/core/src/main/java/com/coresecure/brightcove/wrapper/listeners/BrightcovePublishListener.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import java.io.InputStream;
-import java.util.concurrent.TimeUnit;
 
 import com.coresecure.brightcove.wrapper.sling.ConfigurationGrabber;
 import com.coresecure.brightcove.wrapper.sling.ConfigurationService;
@@ -245,8 +244,12 @@ public class BrightcovePublishListener implements EventHandler {
                     setFolderIdMoveAssetInBC(serviceUtil, parentNode, videoId, folderId);
                 } else {
                     LOG.error("*************************** No folder created ***************************");
-                    TimeUnit.SECONDS.sleep(15);
-                    parentNode.refresh(false);
+                    // Re-read the parent from the persistent store in case a concurrent publish
+                    // created the folder. keepChanges=true: in Oak refresh() is session-wide, so
+                    // refresh(false) would discard pending metadata (e.g. BRC_ID) set before this
+                    // call. No sleep here: this runs on a shared OSGi EventAdmin delivery thread
+                    // and must not block.
+                    parentNode.refresh(true);
                     if (!parentNode.hasProperty("brc_folder_id")) {
                         folderId = serviceUtil.createFolder(assetNode.getParent().getName());
                         if (folderId != null && !folderId.isEmpty()) {

--- a/current/it.tests/pom.xml
+++ b/current/it.tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.4.1</version>
+        <version>7.1.4.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/pom.xml
+++ b/current/pom.xml
@@ -21,7 +21,7 @@
     <groupId>com.coresecure</groupId>
     <artifactId>brightcove</artifactId>
     <packaging>pom</packaging>
-    <version>7.1.4.1</version>
+    <version>7.1.4.2</version>
     <description>Brightcove Connector</description>
 
     <modules>

--- a/current/ui.apps.structure/pom.xml
+++ b/current/ui.apps.structure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.4.1</version>
+        <version>7.1.4.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.apps/pom.xml
+++ b/current/ui.apps/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.4.1</version>
+        <version>7.1.4.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.config/pom.xml
+++ b/current/ui.config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.4.1</version>
+        <version>7.1.4.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.content/pom.xml
+++ b/current/ui.content/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.4.1</version>
+        <version>7.1.4.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.tests/pom.xml
+++ b/current/ui.tests/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.4.1</version>
+        <version>7.1.4.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
## BGS-1600 — videos published from a Brightcove subfolder land in "All Videos"

### Problem
Publishing an asset that lives in a Brightcove-managed **subfolder** uploads the video to Brightcove but leaves it in the default **All Videos** folder. Using the manual **Sync to Brightcove** button on the same asset preserves the folder. The two paths run different code:

- **Sync button / workflow** (`BrightcoveSyncAssetWorkflowStep`) calls `syncFolder()` after create/update, which moves the video into the Brightcove folder mirroring the AEM parent folder.
- **Publish / replication** (`BrightcovePublishListener`) created/updated the video but **never** performed the folder move.

This is a long-standing gap — the publish listener never had folder-sync logic; folder support was only ever added to the workflow path. Restoring the publish-to-Brightcove sync earlier made the gap observable.

### Fix
Add the same `syncFolder()` / `setFolderIdMoveAssetInBC()` logic (including the **account-root guard**) to `activateNew()` and `activateModified()` in the publish listener, so the publish path and the sync-button path behave identically.

Version bumped to **7.1.4.2**.

### Validation (local AEM author + a test Video Cloud account)
- **Subfolder publish:** video created via ingest, then `PUT …/folders/{id}/videos/{id}`; CMS API confirms `folder_id` = the target subfolder (previously null). ✅
- **Account-root publish (regression check):** folder sync correctly **skipped** (`"Asset is at account root level …, skipping Brightcove folder sync"`); CMS API confirms `folder_id` = null, so root-level publishes are not moved into a spurious folder. ✅
- All test artifacts cleaned up afterward.

### Follow-up
The underlying cause is duplicated activate-logic between the listener and the workflow step. This patch replicates `syncFolder` to keep the change surgical on the release line; the proper de-duplication (extract to a shared helper) is tracked separately on `cloud-master`.