### PR TITLE
fix(BCON): admin UI QA cleanup (11 fixes)

### DIFF
--- a/current/core/src/main/java/com/coresecure/brightcove/wrapper/api/CmsAPI.java
+++ b/current/core/src/main/java/com/coresecure/brightcove/wrapper/api/CmsAPI.java
@@ -346,10 +346,35 @@ public class CmsAPI {
                 request.set("labels", labelArray);
                 LOGGER.info("updateVideoParams: {}", request.toPrettyString());
                 String response = account.platform.patchAPI(targetURL, request.toPrettyString(), headers);
-                if (response != null && !response.isEmpty()) json = JsonReader.readJsonFromString(response);
+                if (response != null && !response.isEmpty()) {
+                    // Brightcove returns an object on success ({ ...video fields... })
+                    // and an array on validation failure
+                    // (e.g. [{"error_code":"VALIDATION_ERROR","message":"foo: ILLEGAL_VALUE"}]).
+                    // The old `(ObjectNode) readTree(...)` cast threw on the array form
+                    // and the exception was swallowed below, so the JS client received
+                    // an empty {} and falsely showed "Labels saved" while nothing
+                    // persisted.
+                    com.fasterxml.jackson.databind.JsonNode parsed = JsonReader.readJsonTree(response);
+                    if (parsed.isObject()) {
+                        json = (ObjectNode) parsed;
+                    } else if (parsed.isArray() && parsed.size() > 0) {
+                        com.fasterxml.jackson.databind.JsonNode first = parsed.get(0);
+                        json.put("error_code", 422);
+                        if (first.has("message")) {
+                            json.put("message", first.get("message").asText());
+                        } else if (first.has("error_code")) {
+                            json.put("message", first.get("error_code").asText());
+                        }
+                    }
+                }
             } catch (Exception e) {
                 LOGGER.error(e.getClass().getName(), e);
+                json.put("error_code", 500);
+                json.put("message", e.getClass().getSimpleName() + ": " + e.getMessage());
             }
+        } else {
+            json.put("error_code", 401);
+            json.put("message", "No auth token");
         }
         return json;
     }

--- a/current/core/src/main/java/com/coresecure/brightcove/wrapper/utils/Constants.java
+++ b/current/core/src/main/java/com/coresecure/brightcove/wrapper/utils/Constants.java
@@ -22,6 +22,8 @@ public class Constants {
 
     //JSON KEY CONSTANTS
     public static final String ID = "id";
+    public static final String PATH = "path";
+    public static final String ERROR_CODE = "error_code";
     public static final String ACCOUNT_ID = "account_id";
     public static final String NAME = "name";
     public static final String REFERENCE_ID = "reference_id";

--- a/current/core/src/main/java/com/coresecure/brightcove/wrapper/utils/JsonReader.java
+++ b/current/core/src/main/java/com/coresecure/brightcove/wrapper/utils/JsonReader.java
@@ -32,6 +32,7 @@
  */
 package com.coresecure.brightcove.wrapper.utils;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -50,6 +51,15 @@ public class JsonReader {
 
     public static ArrayNode readJsonArrayFromString(String jsonText) throws IOException {
         return (ArrayNode) MAPPER.readTree(jsonText);
+    }
+
+    // Callers that need to introspect whether the parsed tree is an object or
+    // array (e.g. Brightcove CMS responses use an array body to convey errors
+    // and an object body for success) should use this rather than the typed
+    // helpers above — the typed helpers throw ClassCastException on mismatch
+    // and that exception is easy to swallow into a silent empty result.
+    public static JsonNode readJsonTree(String jsonText) throws IOException {
+        return MAPPER.readTree(jsonText);
     }
 
 }

--- a/current/core/src/main/java/com/coresecure/brightcove/wrapper/webservices/BrcApi.java
+++ b/current/core/src/main/java/com/coresecure/brightcove/wrapper/webservices/BrcApi.java
@@ -340,10 +340,18 @@ public class BrcApi extends SlingAllMethodsServlet {
         LOGGER.info("Creating a Label");
         ObjectNode labelResult = brAPI.cms.createLabel(requestParameter.toString());
 
-        if (!labelResult.has(Constants.ID)) {
-            result.put(Constants.ERROR, 409);
-        } else {
+        // The Brightcove label API returns {"path": ...} on success (201). The
+        // old check keyed on an "id" field the API never returns, so it reported
+        // failure on every successful create. On failure HttpServices synthesises
+        // {"error_code": <status>, ...} — 422 means the path already exists.
+        if (labelResult != null && labelResult.has(Constants.PATH)) {
             result = null;
+        } else if (labelResult != null && labelResult.has(Constants.ERROR_CODE)) {
+            int code = labelResult.get(Constants.ERROR_CODE).asInt();
+            // Surface a duplicate (422) as a 409-style "already exists" for the JS.
+            result.put(Constants.ERROR, code == 422 ? 409 : code);
+        } else {
+            result.put(Constants.ERROR, 409);
         }
         return result;
     }

--- a/current/core/src/main/java/com/coresecure/brightcove/wrapper/webservices/BrcApi.java
+++ b/current/core/src/main/java/com/coresecure/brightcove/wrapper/webservices/BrcApi.java
@@ -62,6 +62,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.coresecure.brightcove.wrapper.utils.JsonReader;
+
 import javax.servlet.ServletException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -645,6 +647,56 @@ public class BrcApi extends SlingAllMethodsServlet {
         ObjectNode videoItem = brAPI.cms.uploadInjest(request.getParameter(Constants.ID), images_payload);
         LOGGER.trace(videoItem.toPrettyString());
 
+        // Parse the DI response so the JS can tell whether the QUEUE succeeded.
+        // (The actual image processing is async — Brightcove returns 200 +
+        // {"id":"<job-id>"} for any payload it accepts, then workers fetch
+        // the URL and update the image minutes later. We can't surface the
+        // job result synchronously, but we MUST surface a queue failure
+        // instead of always claiming success.)
+        ObjectNode ingestResult = JsonNodeFactory.instance.objectNode();
+        boolean ingestQueued = false;
+        if (videoItem.has(Constants.RESPONSE) && !videoItem.get(Constants.RESPONSE).isNull()) {
+            String rawResponse = videoItem.get(Constants.RESPONSE).asText();
+            if (rawResponse != null && !rawResponse.isEmpty()) {
+                try {
+                    com.fasterxml.jackson.databind.JsonNode parsed = JsonReader.readJsonTree(rawResponse);
+                    if (parsed.isObject()) {
+                        ObjectNode obj = (ObjectNode) parsed;
+                        if (obj.has("id")) {
+                            ingestQueued = true;
+                            ingestResult.put("job_id", obj.get("id").asText());
+                        } else if (obj.has("error_code")) {
+                            // Brightcove DI wraps errors as object {"error_code": "...", "message": "..."}
+                            ingestResult.put("error_code", 422);
+                            ingestResult.put("message", obj.has("message") ? obj.get("message").asText() : obj.get("error_code").asText());
+                        } else if (obj.has("error")) {
+                            // executePost's synthesised error wrapper (numeric or string in "error" field).
+                            int code;
+                            try { code = Integer.parseInt(obj.get("error").asText()); }
+                            catch (NumberFormatException nfe) { code = 422; }
+                            ingestResult.put("error_code", code);
+                            ingestResult.put("message", obj.has("error_message") ? obj.get("error_message").asText() : "Ingest queue failed");
+                        }
+                    } else if (parsed.isArray() && parsed.size() > 0) {
+                        // Brightcove validation errors come as an array body.
+                        com.fasterxml.jackson.databind.JsonNode first = parsed.get(0);
+                        ingestResult.put("error_code", 422);
+                        ingestResult.put("message", first.has("message") ? first.get("message").asText() : "Validation error");
+                    }
+                } catch (Exception e) {
+                    LOGGER.error("Failed to parse DI ingest response: {}", rawResponse, e);
+                    ingestResult.put("error_code", 502);
+                    ingestResult.put("message", "Could not parse ingest response");
+                }
+            } else {
+                ingestResult.put("error_code", 502);
+                ingestResult.put("message", "Empty ingest response");
+            }
+        } else {
+            ingestResult.put("error_code", 502);
+            ingestResult.put("message", "No ingest response (auth/transport failure)");
+        }
+
         if (videoItem.has(Constants.RESPONSE) && !videoItem.get(Constants.RESPONSE).isNull()) {
             try {
                 String videoId = request.getParameter(Constants.ID);
@@ -703,7 +755,13 @@ public class BrcApi extends SlingAllMethodsServlet {
             }
         }
 
-        return null;
+        // Return a real response shape so the JS can distinguish queued
+        // (async — image will appear shortly) from queue-failed.
+        if (!ingestQueued && !ingestResult.has("error_code")) {
+            ingestResult.put("error_code", 502);
+            ingestResult.put("message", "Ingest queue failed");
+        }
+        return ingestResult;
     }
 
     private ObjectNode apiLogic(SlingHttpServletRequest request, SlingHttpServletResponse response, ObjectNode jsonObject) throws IOException {

--- a/current/core/src/main/java/com/coresecure/brightcove/wrapper/webservices/BrcApi.java
+++ b/current/core/src/main/java/com/coresecure/brightcove/wrapper/webservices/BrcApi.java
@@ -340,18 +340,41 @@ public class BrcApi extends SlingAllMethodsServlet {
         LOGGER.info("Creating a Label");
         ObjectNode labelResult = brAPI.cms.createLabel(requestParameter.toString());
 
-        // The Brightcove label API returns {"path": ...} on success (201). The
-        // old check keyed on an "id" field the API never returns, so it reported
-        // failure on every successful create. On failure HttpServices synthesises
-        // {"error_code": <status>, ...} — 422 means the path already exists.
+        // The Brightcove label API returns {"path": ...} on success (201). On
+        // failure HttpServices synthesises an error object — but its field
+        // name is method-dependent: executePost writes `"error"` (with the
+        // upstream `error_code` STRING like "RESOURCE_ALREADY_EXISTS" as the
+        // value when the body parsed, or the numeric HTTP status when it
+        // didn't), while executePut/Delete/Patch (and the exception paths)
+        // write `"error_code"` numerically. The previous version only
+        // checked `error_code`, so every POST failure fell through to the
+        // final `else` returning 409 — every error read as "already exists",
+        // even unrelated 4xx/5xx (cursorbot review on PR #108).
         if (labelResult != null && labelResult.has(Constants.PATH)) {
             result = null;
-        } else if (labelResult != null && labelResult.has(Constants.ERROR_CODE)) {
-            int code = labelResult.get(Constants.ERROR_CODE).asInt();
+        } else if (labelResult != null && (labelResult.has(Constants.ERROR_CODE) || labelResult.has(Constants.ERROR))) {
+            com.fasterxml.jackson.databind.JsonNode raw = labelResult.has(Constants.ERROR_CODE)
+                    ? labelResult.get(Constants.ERROR_CODE)
+                    : labelResult.get(Constants.ERROR);
+            String text = raw.asText();
+            int code;
+            try {
+                code = Integer.parseInt(text);
+            } catch (NumberFormatException nfe) {
+                // Upstream code came through as a string (executePost happy-error
+                // path). Map known duplicate signals to 422, everything else to
+                // 500 so the JS surfaces "Could not create" not "already exists".
+                code = ("RESOURCE_ALREADY_EXISTS".equals(text) || "VALIDATION_ERROR".equals(text))
+                        ? 422 : 500;
+            }
             // Surface a duplicate (422) as a 409-style "already exists" for the JS.
             result.put(Constants.ERROR, code == 422 ? 409 : code);
         } else {
-            result.put(Constants.ERROR, 409);
+            // Shape we don't recognise (executePost returning empty / null,
+            // transport-level failure with no body at all). Used to be a hard
+            // 409 — that mislabelled every weird failure as a duplicate. 500
+            // is the honest answer.
+            result.put(Constants.ERROR, 500);
         }
         return result;
     }

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -2771,6 +2771,9 @@ body.brc-mtf-open {
   top: 0;
   max-height: 100vh;
   overflow-y: auto;
+  /* BCON-175: outer border divides the Properties panel from the list section. */
+  border: 1px solid #e8e6df;
+  background: #fff;
 }
 
 .brc-panel-header {
@@ -2779,6 +2782,8 @@ body.brc-mtf-open {
   justify-content: space-between;
   padding: 16px 16px 12px;
   border-bottom: 1px solid #f0efea;
+  /* BCON-175: header has a grey background, distinct from the section body. */
+  background: #f7f6f2;
 }
 
 .brc-panel-title {
@@ -2827,6 +2832,8 @@ body.brc-mtf-open {
 /* Image widgets */
 .brc-panel-images {
   display: flex;
+  /* BCON-175: images stack vertically (was side-by-side). */
+  flex-direction: column;
   gap: 12px;
 }
 
@@ -2908,11 +2915,17 @@ body.brc-mtf-open {
 /* Video info table */
 .brc-panel-info-table {
   width: 100%;
-  border-collapse: collapse;
+  /* BCON-175: outer border around the Video Info section. `separate` keeps
+     row dividers + lets the outer border render with rounded corners. */
+  border-collapse: separate;
+  border-spacing: 0;
+  border: 1px solid #e8e6df;
+  border-radius: 8px;
+  overflow: hidden;
 }
 
 .brc-panel-info-table td {
-  padding: 7px 0;
+  padding: 7px 10px;
   border-bottom: 1px solid #f0efea;
   font-size: 13px;
   color: #1a1a18;
@@ -2921,6 +2934,22 @@ body.brc-mtf-open {
 
 .brc-panel-info-table tr:last-child td {
   border-bottom: none;
+}
+
+/* BCON-175: value cells right-justified; label cells stay left. */
+.brc-panel-info-table td:not(.brc-info-label) {
+  text-align: right;
+}
+
+/* BCON-175: Economics renders as a bubble/pill around the value. */
+#divMeta\.economics:not(:empty) {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 99px;
+  background: #f0efea;
+  font-size: 12px;
+  color: #1a1a18;
+  line-height: 1.4;
 }
 
 .brc-info-label {

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -1478,6 +1478,10 @@ table.tblConsole #tbData td:nth-child(2) {
 .brc-filter-checkbox input[type="checkbox"] {
   -webkit-appearance: none;
   appearance: none;
+  /* inline-block so the explicit width/height apply — the select-all header
+     checkbox was rendering as display:inline, which ignores width/height and
+     collapsed it to a near-invisible 2x3px box. */
+  display: inline-block;
   width: 15px;
   height: 15px;
   border: 1.5px solid #c8c7c2;

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -3007,6 +3007,95 @@ body.brc-mtf-open {
   line-height: 1;
 }
 
+/* BCON-187: TEXT TRACKS section — pill rows under their own section title. */
+.brc-track-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.brc-track-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border: 1px solid #e8e6df;
+  border-radius: 8px;
+  background: #fff;
+  font-size: 13px;
+}
+
+.brc-track-label {
+  flex: 1 1 auto;
+  color: #1a1a18;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.brc-track-kind,
+.brc-track-default {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 99px;
+  font-size: 11px;
+  line-height: 1.4;
+  flex: 0 0 auto;
+}
+
+.brc-track-kind {
+  background: #eef2ff;
+  color: #3730a3;
+}
+
+.brc-track-kind--captions {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.brc-track-kind--subtitles {
+  background: #dbeafe;
+  color: #1e3a8a;
+}
+
+.brc-track-kind--descriptions {
+  background: #ede9fe;
+  color: #5b21b6;
+}
+
+.brc-track-kind--chapters {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.brc-track-kind--metadata {
+  background: #f1f5f9;
+  color: #334155;
+}
+
+.brc-track-default {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.brc-track-delete {
+  background: none;
+  border: none;
+  padding: 4px;
+  cursor: pointer;
+  color: #6b7280;
+  display: inline-flex;
+  align-items: center;
+  border-radius: 4px;
+  flex: 0 0 auto;
+}
+
+.brc-track-delete:hover {
+  background: #f7f6f2;
+  color: #b91c1c;
+}
+
 .brc-label-input {
   width: 100%;
   border: 1px solid #e8e6df;

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -3887,6 +3887,8 @@ body.brc-mtf-open {
 .brc-tt-suggestion-item:hover,
 .brc-tt-suggestion-item.is-active {
   background: #f7f6f2;
+}
+
 /* ---- BCON-148: Sync database loading overlay (frame J) ---- */
 .brc-sync-overlay {
   position: fixed;

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -1066,11 +1066,6 @@ div.delConfPop {
   padding-right: 5px;
 }
 
-#divMeta.shortDescription pre {
-  white-space: pre-wrap;
-  margin-top: 5px;
-}
-
 #divMeta.labels a {
   display: block;
   margin-bottom: 2px;

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -2888,6 +2888,72 @@ body.brc-mtf-open {
   background: #f7f6f2;
 }
 
+/* BCON-184: inline image URL editor (replaces the popup). */
+.brc-image-url-edit {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.brc-image-url-input {
+  width: 100%;
+  border: 1px solid #e8e6df;
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-size: 12px;
+  font-family: inherit;
+  color: #1a1a18;
+  box-sizing: border-box;
+}
+
+.brc-image-url-input:focus {
+  outline: none;
+  border-color: #1a1a18;
+}
+
+.brc-image-url-edit-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.brc-image-url-save,
+.brc-image-url-cancel {
+  flex: 1 1 0;
+  border: 1px solid #e8e6df;
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.brc-image-url-save {
+  background: #1a1a18;
+  color: #fff;
+  border-color: #1a1a18;
+  font-weight: 500;
+}
+
+.brc-image-url-save:hover {
+  background: #000;
+}
+
+.brc-image-url-save[disabled] {
+  background: #6b7280;
+  border-color: #6b7280;
+  cursor: not-allowed;
+}
+
+.brc-image-url-cancel {
+  background: #fff;
+  color: #1a1a18;
+}
+
+.brc-image-url-cancel:hover {
+  background: #f7f6f2;
+}
+
 /* Action buttons */
 .brc-panel-action-btn {
   display: block;

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -420,6 +420,10 @@ betty-titlebar {
   align-items: center;
   gap: 12px;
   margin-left: 6px;
+  /* When the viewport is narrow, wrap the bar to a new row instead of
+     letting the buttons shrink and wrap their labels (BCON-181). */
+  flex-wrap: wrap;
+  row-gap: 8px;
 }
 
 .brc-bulk-bar[hidden] {
@@ -463,6 +467,10 @@ betty-titlebar {
   filter: none;
   margin: 0;
   line-height: 32px;
+  /* Keep each button its natural size on one line — don't let flex shrink
+     them until their labels wrap (BCON-181). */
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 
 .brc-bulk-bar-btn:hover {
@@ -1493,13 +1501,16 @@ table.tblConsole #tbData td:nth-child(2) {
   content: '';
   display: block;
   position: absolute;
-  left: 3px;
-  top: 0;
+  /* Center the checkmark in the box. The tick's elbow sits toward the
+     bottom of its bounding box, so nudge up slightly (-60% Y) so it reads
+     as centered rather than low. */
+  left: 50%;
+  top: 50%;
   width: 4px;
   height: 8px;
   border-right: 1.5px solid #fff;
   border-bottom: 1.5px solid #fff;
-  transform: rotate(45deg);
+  transform: translate(-50%, -60%) rotate(45deg);
 }
 
 #playerDiv.overlay.ui-draggable {

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcAdmin.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcAdmin.js
@@ -116,8 +116,11 @@ function getFindPlaylistsURL() {
                 '.js?account_id='+$("#selAccount").val()+'&a=search_playlists&callback=showAllPlaylistsCallBack&query=' + searchVal
                 + '&limit=' + paging.size + '&start=' + paging.allPlaylists
         } else if (searchField == "find_playlist_by_name") {
+            // Brightcove's playlist search `q` performs a name search directly;
+            // it does not accept the field-qualified `name:` syntax used for
+            // video search (that returns zero results). Send the bare term.
             return apiLocation +
-                '.js?account_id='+$("#selAccount").val()+'&a=search_playlists&callback=showAllPlaylistsCallBack&query=name:' + searchVal
+                '.js?account_id='+$("#selAccount").val()+'&a=search_playlists&callback=showAllPlaylistsCallBack&query=' + searchVal
                 + '&limit=' + paging.size + '&start=' + paging.allPlaylists
         } else if (searchField == "find_playlist_by_id") {
             return apiLocation +

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -1842,7 +1842,9 @@ function buildPlaylistList() {
                 $('<button>', {
                     type: 'button',
                     class: 'edit-playlist brc-playlist-name-btn',
-                    'data-playlist-id': n.id
+                    'data-playlist-id': n.id,
+                    'data-playlist-name': n.name,
+                    'data-playlist-type': n.type || ''
                 }).text(n.name)
             )
         );

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -2062,20 +2062,58 @@ function showMetaData(idx) {
 
     $('#divMeta\\.folder').text(v.folder_id ? v.folder_id : 'All Videos');
 
-    // Text tracks
+    // Text tracks — render via shared helper into the BCON-187 section.
     $ACTIVE_TRACKS = v.text_tracks != null ? v.text_tracks : "";
-    var arr = v.text_tracks != null ? v.text_tracks : "";
-    document.getElementById('divMeta.text_tracks').innerHTML = "";
+    renderTextTracksSection(v.text_tracks, v.id);
+}
 
-    if (arr.length > 0) {
-        var tableTmpl = "<table class=\"tg\"><thead><tr><th class=\"tg-uqo3\">LABEL</th><th class=\"tg-uqo3\">LANGUAGE</th> <th class=\"tg-uqo3\">TYPE</th> <th class=\"tg-uqo3\">DELETE</th> </tr> </thead><tbody id=\"divMeta.text_tracks_table\"></tbody></table>";
-        document.getElementById('divMeta.text_tracks').innerHTML = tableTmpl;
-        for (var x = 0; x < arr.length; x++) {
-            var cur = arr[x];
-            var defTrack = cur["default"] ? "default_track" : "";
-            document.getElementById('divMeta.text_tracks_table').innerHTML += "<tr class='texttrackrow " + defTrack + "'><td class=\"tg-baqh \">" + cur.label + "</td><td class=\"tg-baqh\">" + cur.srclang + "</td><td class=\"tg-baqh\">" + cur.kind + "</td><td class=\"tg-baqh delete_button\" onClick=\"deleteTrack('" + cur.id + "','" + v.id + "')\">X</td></tr>";
+// Map a BCP-47 language tag to its English display name (e.g. "en" → "English",
+// "ja-JP" → "Japanese"). Falls back to the raw tag when the runtime doesn't
+// have Intl.DisplayNames.
+function _languageDisplay(srclang) {
+    if (!srclang) return '';
+    try {
+        if (typeof Intl !== 'undefined' && Intl.DisplayNames) {
+            var dn = new Intl.DisplayNames(['en'], { type: 'language' });
+            var name = dn.of(srclang);
+            if (name) return name;
         }
+    } catch (e) { /* fall through to the raw tag */ }
+    return srclang;
+}
+
+// BCON-187: render the TEXT TRACKS section as pill rows under its own
+// section header (was an unstyled table jammed into ACTIONS, above the
+// upload button). Hides the section entirely when there are no tracks.
+function renderTextTracksSection(tracks, videoId) {
+    var $section = $('#textTracksSection');
+    var $list = $('#divMeta\\.text_tracks').empty();
+    if (!tracks || !tracks.length) {
+        $section.attr('hidden', '');
+        return;
     }
+    $section.removeAttr('hidden');
+    tracks.forEach(function(t) {
+        var label = t.label || _languageDisplay(t.srclang) || t.srclang || 'Untitled';
+        var kind = (t.kind || 'subtitles').toLowerCase();
+        var kindDisplay = kind.charAt(0).toUpperCase() + kind.slice(1);
+        var $row = $('<div class="brc-track-row">');
+        $row.append($('<span class="brc-track-label">').text(label));
+        $row.append($('<span class="brc-track-kind">').addClass('brc-track-kind--' + kind).text(kindDisplay));
+        if (t['default']) {
+            $row.append($('<span class="brc-track-default">').text('Default'));
+        }
+        var $del = $('<button type="button" class="brc-track-delete" aria-label="Delete track">');
+        $del.append($('<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+            '<polyline points="3 6 5 6 21 6"/>' +
+            '<path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/>' +
+            '<path d="M10 11v6"/><path d="M14 11v6"/>' +
+            '<path d="M9 6V4a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2"/>' +
+            '</svg>'));
+        $del.on('click', function() { deleteTrack(t.id, videoId); });
+        $row.append($del);
+        $list.append($row);
+    });
 }
 
 // _cameraIcon / renderLabelPills / keydown #labelInput / saveLabels are
@@ -2164,18 +2202,7 @@ function showMetaDataByVideoID(idx) {
             showVariants(v, vidIdx);
 
             $ACTIVE_TRACKS = v.text_tracks != null ? v.text_tracks : "";
-            var arr = v.text_tracks != null ? v.text_tracks : "";
-            document.getElementById('divMeta.text_tracks').innerHTML = "";
-
-            if (arr.length > 0) {
-                var tableTmpl = "<table class=\"tg\"><thead><tr><th class=\"tg-uqo3\">LABEL</th><th class=\"tg-uqo3\">LANGUAGE</th> <th class=\"tg-uqo3\">TYPE</th> <th class=\"tg-uqo3\">DELETE</th> </tr> </thead><tbody id=\"divMeta.text_tracks_table\"></tbody></table>";
-                document.getElementById('divMeta.text_tracks').innerHTML = tableTmpl;
-                for (var x = 0; x < arr.length; x++) {
-                    var cur = arr[x];
-                    var defTrack = cur["default"] ? "default_track" : "";
-                    document.getElementById('divMeta.text_tracks_table').innerHTML += "<tr class='texttrackrow " + defTrack + "'><td class=\"tg-baqh \">" + cur.label + "</td><td class=\"tg-baqh\">" + cur.srclang + "</td><td class=\"tg-baqh\">" + cur.kind + "</td><td class=\"tg-baqh delete_button\" onClick=\"deleteTrack('" + cur.id + "','" + v.id + "')\">X</td></tr>";
-                }
-            }
+            renderTextTracksSection(v.text_tracks, v.id);
             $('#divMeta\\.folder').text(v.folder_id ? v.folder_id : 'All Videos');
 
             _currentLabels = v.labels ? (Array.isArray(v.labels) ? v.labels.slice() : v.labels.toString().split(',').filter(Boolean)) : [];

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -1482,16 +1482,6 @@ function epSavePlaylist(showToast) {
         playlistId: _epPlaylistId,
         playlistName: playlistName
     };
-    if (!isSmart) {
-        var ids = epVideoIds();
-        if (ids.length === 0) {
-            playlistData['clearVideos'] = true;
-        } else {
-            playlistData['videos'] = ids;
-        }
-    }
-
-    epSetSaving(true);
 
     // Build the query string manually for the videos portion so we bypass
     // jQuery's $.param behaviour of dropping empty arrays entirely.  When the

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -2013,6 +2013,9 @@ function showMetaData(idx) {
     idx = oCurrentVideoList.length > idx ? idx : 0;
     $("#tbData>tr:eq(" + idx + ")").addClass("select");
 
+    // BCON-184: reset any leftover inline URL-edit from a previous video.
+    $('.brc-image-widget').each(function() { _exitImageUrlEdit($(this)); });
+
     var v = oCurrentVideoList[idx];
 
     showVariants(v, idx);
@@ -2151,6 +2154,10 @@ function showMetaDataByVideoID(idx) {
     $("tr.select").removeClass("select");
     $("#tbData>tr:eq(" + idx + ")").addClass("select");
 
+    // BCON-184: any leftover inline URL-edit from a previous video should
+    // close on switch — otherwise the new video opens with the previous
+    // video's URL still typed in.
+    $('.brc-image-widget').each(function() { _exitImageUrlEdit($(this)); });
 
     $.ajax({
         url: getVideoAPIURL(idx),
@@ -2428,131 +2435,95 @@ function syncDB()
 }
 
 
-function uploadPoster()
-{
-    // first cleanup any existing dialogs
-    var elem = document.querySelector('#upload_poster_dialog');
-    if (elem) {
-        elem.parentNode.removeChild(elem);
-    }
+// BCON-184: Image URL editing happens INSIDE the image widget instead of in
+// a Coral.Dialog popup. Each widget carries `data-image-kind`, `data-field`,
+// and `data-preview-id` attrs identifying how to post the change and which
+// preview to update. The widget toggles between two children:
+//   .brc-image-url-btn   (resting state — "ENTER URL")
+//   .brc-image-url-edit  (editing — input + Save + Cancel)
+//
+// `uploadPoster()` / `uploadThumbnail()` survive as the inline-onclick entry
+// points and delegate to the shared helper.
+function uploadPoster()    { _enterImageUrlEdit($('.brc-image-widget[data-image-kind="poster"]')); }
+function uploadThumbnail() { _enterImageUrlEdit($('.brc-image-widget[data-image-kind="thumbnail"]')); }
 
-    var dialog = new Coral.Dialog().set({
-        id: 'upload_poster_dialog',
-        header: {
-          innerHTML: 'Update Poster Image'
-        },
-        content: {
-          innerHTML: '<form class="coral-Form coral-Form--vertical">' +
-          '<div class="coral-Form-fieldwrapper">' +
-          '<label class="coral-Form-fieldlabel" id="label-vertical-textfield-0">Poster Source URL</label>' +
-          '<input is="coral-textfield" class="coral-Form-field" placeholder="https://" name="name" id="upload_poster_dialog_field_source" labelledby="label-vertical-textfield-0"' +
-          'value="' + ($('#divMeta\\.posterPreview img').attr('src') || '') + '"' +
-          '></div></form>'
-        },
-        footer: {
-          innerHTML: '<button is="coral-button" id="upload_poster_dialog_click" variant="primary">Upload</button><button is="coral-button" variant="quiet" coral-close>Cancel</button>'
-        }
-    });
-    dialog.on('click', '#upload_poster_dialog_click', function() {
-        if ($('#upload_poster_dialog_field_source').val() != '') {
-            var fields = {
-                limit: paging.size,
-                start: paging.generic,
-                id: document.getElementById('divMeta.id').innerHTML,
-                a: 'upload_image',
-                account_id: $("#selAccount").val(),
-                poster_source: $('#upload_poster_dialog_field_source').val()
-            }
-            console.log(fields);
-            $.ajax({
-                url: apiLocation + '.js',
-                type: 'POST',
-                data: fields,
-                success: function () {
-                    var url = $('#upload_poster_dialog_field_source').val();
-                    $('#divMeta\\.posterPreview').empty().append($('<img>').attr('src', url));
-                    $('#posterUrlBtn').text('ENTER URL');
-                    dialog.hide();
-                    brcToast('Poster updated');
-                },
-                error: function ( data )
-                {
-                    console.log(data);
-                    alert('Oops! There was an error with your submission. Please try again.');
-                }
-            });
-        } else {
-            alert('Please provide a valid poster image source URL.');
-        }
-
-    });
-    document.body.appendChild(dialog);
-    dialog.show();
-
+function _enterImageUrlEdit($widget) {
+    if (!$widget || !$widget.length) return;
+    var $btn   = $widget.find('.brc-image-url-btn');
+    var $edit  = $widget.find('.brc-image-url-edit');
+    var $input = $edit.find('.brc-image-url-input');
+    var $preview = $widget.find('.brc-image-preview img');
+    $input.val($preview.attr('src') || '');
+    $btn.attr('hidden', '');
+    $edit.removeAttr('hidden');
+    $input.trigger('focus').get(0).select && $input.get(0).select();
 }
 
-function uploadThumbnail()
-{
-    // first cleanup any existing dialogs
-    var elem = document.querySelector('#upload_thumbnail_dialog');
-    if (elem) {
-        elem.parentNode.removeChild(elem);
-    }
-
-    var dialog = new Coral.Dialog().set({
-        id: 'upload_thumbnail_dialog',
-        header: {
-          innerHTML: 'Update Thumbnail'
-        },
-        content: {
-          innerHTML: '<form class="coral-Form coral-Form--vertical">' +
-          '<div class="coral-Form-fieldwrapper">' +
-          '<label class="coral-Form-fieldlabel" id="label-vertical-textfield-0">Thumbnail Source URL</label>' +
-          '<input is="coral-textfield" class="coral-Form-field" placeholder="https://" name="name" id="upload_thumbnail_dialog_field_source" labelledby="label-vertical-textfield-0"' +
-          'value="' + ($('#divMeta\\.thumbPreview img').attr('src') || '') + '"' +
-          '></div></form>'
-        },
-        footer: {
-          innerHTML: '<button is="coral-button" id="upload_thumbnail_dialog_click" variant="primary">Upload</button><button is="coral-button" variant="quiet" coral-close>Cancel</button>'
-        }
-    });
-    dialog.on('click', '#upload_thumbnail_dialog_click', function() {
-        if ($('#upload_thumbnail_dialog_field_source').val() != '') {
-            var fields = {
-                limit: paging.size,
-                start: paging.generic,
-                id: document.getElementById('divMeta.id').innerHTML,
-                a: 'upload_image',
-                account_id: $("#selAccount").val(),
-                thumbnail_source: $('#upload_thumbnail_dialog_field_source').val()
-            }
-            console.log(fields);
-            $.ajax({
-                url: apiLocation + '.js',
-                type: 'POST',
-                data: fields,
-                success: function () {
-                    var url = $('#upload_thumbnail_dialog_field_source').val();
-                    $('#divMeta\\.thumbPreview').empty().append($('<img>').attr('src', url));
-                    $('#thumbUrlBtn').text('ENTER URL');
-                    dialog.hide();
-                    brcToast('Thumbnail updated');
-                },
-                error: function ( data )
-                {
-                    console.log(data);
-                    alert('Oops! There was an error with your submission. Please try again.');
-                }
-            });
-        } else {
-            alert('Please provide a valid thumbnail source URL.');
-        }
-
-    });
-    document.body.appendChild(dialog);
-    dialog.show();
-
+function _exitImageUrlEdit($widget) {
+    if (!$widget || !$widget.length) return;
+    $widget.find('.brc-image-url-edit').attr('hidden', '');
+    $widget.find('.brc-image-url-btn').removeAttr('hidden');
 }
+
+$(document).on('click', '.brc-image-url-cancel', function() {
+    _exitImageUrlEdit($(this).closest('.brc-image-widget'));
+});
+
+$(document).on('keydown', '.brc-image-url-input', function(e) {
+    if (e.key === 'Escape') {
+        _exitImageUrlEdit($(this).closest('.brc-image-widget'));
+    } else if (e.key === 'Enter') {
+        e.preventDefault();
+        $(this).closest('.brc-image-widget').find('.brc-image-url-save').trigger('click');
+    }
+});
+
+$(document).on('click', '.brc-image-url-save', function() {
+    var $widget = $(this).closest('.brc-image-widget');
+    var $input  = $widget.find('.brc-image-url-input');
+    var $save   = $widget.find('.brc-image-url-save');
+    var $cancel = $widget.find('.brc-image-url-cancel');
+    var field   = $widget.attr('data-field');                   // poster_source | thumbnail_source
+    var kind    = $widget.attr('data-image-kind');              // poster | thumbnail
+    var previewId = $widget.attr('data-preview-id');            // divMeta.<...>Preview
+    var url = ($input.val() || '').trim();
+    if (!url) { brcToast('Enter an image URL'); return; }
+
+    var originalLabel = $save.text();
+    $save.prop('disabled', true).text('Saving…');
+    $cancel.prop('disabled', true);
+    $input.prop('disabled', true);
+
+    var fields = {
+        limit: paging.size,
+        start: paging.generic,
+        id: document.getElementById('divMeta.id').innerHTML,
+        a: 'upload_image',
+        account_id: $("#selAccount").val()
+    };
+    fields[field] = url;
+
+    $.ajax({
+        url: apiLocation + '.js',
+        type: 'POST',
+        data: fields,
+        success: function() {
+            var safeId = previewId.replace(/\./g, '\\.');
+            $('#' + safeId).empty().append($('<img>').attr('src', url));
+            _exitImageUrlEdit($widget);
+            brcToast((kind === 'thumbnail' ? 'Thumbnail' : 'Poster') + ' updated');
+            $save.prop('disabled', false).text(originalLabel);
+            $cancel.prop('disabled', false);
+            $input.prop('disabled', false);
+        },
+        error: function() {
+            brcToast((kind === 'thumbnail' ? 'Thumbnail' : 'Poster') + ' update failed — please try again');
+            $save.prop('disabled', false).text(originalLabel);
+            $cancel.prop('disabled', false);
+            $input.prop('disabled', false);
+        }
+    });
+});
 
 function uploadtrack()
 {

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -1608,6 +1608,21 @@ function sort(object) {
                 return asc ? cmp : -cmp;
             });
             buildPlaylistList();
+        } else if (sortBy === 'id' && window.brcCurrentView === 'videos') {
+            // Brightcove video search does not support sort=id: the CMS API
+            // rejects it and returns zero results, which blanked the entire
+            // list (BCON-183). Sort the loaded videos client-side by numeric
+            // id instead, mirroring the playlist path above. IDs can exceed
+            // 2^53 so compare in string space: shorter string = smaller
+            // number, then lexicographic for equal lengths.
+            var ascId = sortType === '';
+            oCurrentVideoList.sort(function (a, b) {
+                var av = a.id != null ? String(a.id) : '';
+                var bv = b.id != null ? String(b.id) : '';
+                var cmp = av.length !== bv.length ? (av.length - bv.length) : (av < bv ? -1 : av > bv ? 1 : 0);
+                return ascId ? cmp : -cmp;
+            });
+            buildMainVideoList(document.getElementById('headTitle').innerHTML);
         } else {
             Load(getAllVideosURLOrdered(sortBy, sortType));
         }

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -955,10 +955,11 @@ $(function () {
     });
 
     $('#uttUpload').on('click', function () {
+        var videoId = document.getElementById('divMeta.id').innerHTML;
         var fields = {
             limit: paging.size,
             start: paging.generic,
-            id: document.getElementById('divMeta.id').innerHTML,
+            id: videoId,
             track_lang: $('#uttLanguage').val(),
             track_label: $('#uttLabel').val(),
             track_kind: $('#uttKind').val(),
@@ -969,19 +970,41 @@ $(function () {
             account_id: $('#selAccount').val()
         };
 
+        // BCON-186: in-flight feedback. Disable the modal's Upload button +
+        // swap its label to "Uploading…" so the user sees the action took
+        // effect. The full-page reload that hid this gap previously is now
+        // gone; the panel re-renders in place on success.
+        var $uploadBtn = $('#uttUpload');
+        var originalLabel = $uploadBtn.text();
+        function setUploading(on) {
+            if (on) {
+                $uploadBtn.prop('disabled', true).text('Uploading…');
+            } else {
+                $uploadBtn.prop('disabled', false).text(originalLabel);
+            }
+        }
+
         function doUpload() {
+            setUploading(true);
             $.ajax({
                 url: apiLocation + '.js',
                 type: 'POST',
                 data: fields,
                 success: function () {
-                    window.selectedVideoId = document.getElementById('divMeta.id').innerHTML;
-                    Load(getAllVideosURL());
                     closeUttModal();
-                    location.reload();
+                    setUploading(false);
+                    brcToast('Text track uploaded');
+                    // Re-fetch this video so the new track appears in the
+                    // TEXT TRACKS section without a full page reload (which
+                    // would re-render everything + lose scroll position).
+                    if (videoId) {
+                        window.selectedVideoId = videoId;
+                        showMetaDataByVideoID(videoId);
+                    }
                 },
                 error: function () {
-                    alert('Oops! There was an error with your text track submission. Please try again.');
+                    setUploading(false);
+                    brcToast('Text track upload failed — please try again');
                 }
             });
         }
@@ -996,7 +1019,7 @@ $(function () {
                 doUpload();
             };
             reader.onerror = function () {
-                alert('Oops! Could not read the selected file. Please try again.');
+                brcToast('Could not read the selected file — please try again');
             };
             reader.readAsText(file);
         } else {

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -2078,58 +2078,11 @@ function showMetaData(idx) {
     }
 }
 
-function _cameraIcon() {
-    return $('<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">' +
-        '<path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" stroke="#6b7280" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>' +
-        '<circle cx="12" cy="13" r="4" stroke="#6b7280" stroke-width="2"/>' +
-        '</svg>');
-}
+// _cameraIcon / renderLabelPills / keydown #labelInput / saveLabels are
+// defined further down (search for `function _cameraIcon`). They used to
+// live here too — the duplicate top-level binding of the keydown handler
+// caused every Enter press in the label input to dispatch twice.
 
-function renderLabelPills() {
-    var $container = $('#divMeta\\.labels').empty();
-    _currentLabels.forEach(function(label) {
-        var $pill = $('<span class="brc-label-pill">')
-            .append($('<span>').text(label))
-            .append(
-                $('<button class="brc-label-pill-remove" type="button" aria-label="Remove">').text('×')
-                    .on('click', function() {
-                        var i = _currentLabels.indexOf(label);
-                        if (i > -1) _currentLabels.splice(i, 1);
-                        $(this).closest('.brc-label-pill').remove();
-                    })
-            );
-        $container.append($pill);
-    });
-}
-
-$(document).on('keydown', '#labelInput', function(e) {
-    if (e.key !== 'Enter') return;
-    e.preventDefault();
-    var val = $(this).val().trim();
-    if (!val || _currentLabels.indexOf(val) > -1) return;
-    _currentLabels.push(val);
-    renderLabelPills();
-    $(this).val('');
-});
-
-function saveLabels() {
-    var videoId = $('#divMeta\\.id').text().trim();
-    if (!videoId) return;
-    var savedLabels = _currentLabels.slice();
-    $.ajax({
-        type: 'GET',
-        url: '/bin/brightcove/api.js',
-        data: $.param({ a: 'update_labels', labels: savedLabels, videoId: videoId }, true),
-        async: true,
-        success: function() {
-            var idx = parseInt($('tr.select').attr('id'), 10);
-            if (!isNaN(idx) && oCurrentVideoList[idx]) {
-                oCurrentVideoList[idx].labels = savedLabels;
-            }
-            brcToast('Labels saved');
-        }
-    });
-}
 function showMetaDataByVideoID(idx) {
 
     window.selectedVideoId = false;
@@ -2268,12 +2221,40 @@ function renderLabelPills() {
     });
 }
 
+// Normalize a user-typed label to Brightcove's canonical /-prefixed-/-suffixed
+// form. Brightcove rejects bare or partial paths with a 422 ILLEGAL_VALUE,
+// and the rejection wipes the entire labels array atomically — so a stale
+// "foo" alongside a known "/test/demo/" loses both.
+function normalizeLabelPath(s) {
+    if (!s) return s;
+    if (s.charAt(0) !== '/') s = '/' + s;
+    if (s.charAt(s.length - 1) !== '/') s = s + '/';
+    return s;
+}
+
+// The known-labels set is the same one loadLabelCallback uses to populate
+// the Labels dropdown. We read from the populated <option>s rather than
+// keeping a parallel cache so the source of truth stays the dropdown.
+function knownLabelPaths() {
+    return $('#label_list option').map(function() { return $(this).val(); }).get()
+        .filter(function(v) { return v && v !== 'create'; });
+}
+
 $(document).on('keydown', '#labelInput', function(e) {
     if (e.key !== 'Enter') return;
     e.preventDefault();
-    var val = $(this).val().trim();
-    if (!val || _currentLabels.indexOf(val) > -1) return;
-    _currentLabels.push(val);
+    var raw = $(this).val().trim();
+    if (!raw) return;
+    var normalized = normalizeLabelPath(raw);
+    if (knownLabelPaths().indexOf(normalized) === -1) {
+        brcToast('Label "' + raw + '" not found — create it via the Labels dropdown first');
+        return;
+    }
+    if (_currentLabels.indexOf(normalized) > -1) {
+        $(this).val('');
+        return;
+    }
+    _currentLabels.push(normalized);
     renderLabelPills();
     $(this).val('');
 });
@@ -2285,14 +2266,28 @@ function saveLabels() {
     $.ajax({
         type: 'GET',
         url: '/bin/brightcove/api.js',
+        // The endpoint is JSONP — let jQuery wire the callback so the response
+        // body is actually parsed into `resp`. The prior `dataType` omission
+        // caused the response to be executed as a script (`cb({...})`) and the
+        // success handler arg to be the source text — meaning the handler
+        // unconditionally toasted "Labels saved" even on a 422 from Brightcove.
         data: $.param({ a: 'update_labels', labels: savedLabels, videoId: videoId }, true),
+        dataType: 'jsonp',
+        jsonp: 'callback',
         async: true,
-        success: function() {
+        success: function(resp) {
+            if (resp && resp.error_code) {
+                brcToast('Labels not saved: ' + (resp.message || 'Brightcove rejected one or more labels'));
+                return;
+            }
             var idx = parseInt($('tr.select').attr('id'), 10);
             if (!isNaN(idx) && oCurrentVideoList[idx]) {
                 oCurrentVideoList[idx].labels = savedLabels;
             }
             brcToast('Labels saved');
+        },
+        error: function() {
+            brcToast('Labels not saved: server error');
         }
     });
 }

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -2004,7 +2004,7 @@ function showMetaData(idx) {
     var posterSrc = (v.images && v.images.poster && v.images.poster.src) ? v.images.poster.src : null;
     if (posterSrc) {
         $posterPreview.append($('<img>').attr('src', posterSrc));
-        $('#posterUrlBtn').text('Change URL');
+        $('#posterUrlBtn').text('ENTER URL');
     } else {
         $posterPreview.append(_cameraIcon());
         $('#posterUrlBtn').text('ENTER URL');
@@ -2015,7 +2015,7 @@ function showMetaData(idx) {
     var thumbSrc = v.thumbnailURL || null;
     if (thumbSrc) {
         $thumbPreview.append($('<img>').attr('src', thumbSrc));
-        $('#thumbUrlBtn').text('Change URL');
+        $('#thumbUrlBtn').text('ENTER URL');
     } else {
         $thumbPreview.append(_cameraIcon());
         $('#thumbUrlBtn').text('ENTER URL');
@@ -2154,13 +2154,13 @@ function showMetaDataByVideoID(idx) {
             // Poster preview
             var $posterPreview = $('#divMeta\\.posterPreview').empty();
             var posterSrc = (v.images && v.images.poster && v.images.poster.src) ? v.images.poster.src : null;
-            if (posterSrc) { $posterPreview.append($('<img>').attr('src', posterSrc)); $('#posterUrlBtn').text('Change URL'); }
+            if (posterSrc) { $posterPreview.append($('<img>').attr('src', posterSrc)); $('#posterUrlBtn').text('ENTER URL'); }
             else { $posterPreview.append(_cameraIcon()); $('#posterUrlBtn').text('ENTER URL'); }
 
             // Thumbnail preview
             var $thumbPreview = $('#divMeta\\.thumbPreview').empty();
             var thumbSrc = (v.images && v.images.thumbnail && v.images.thumbnail.src) ? v.images.thumbnail.src : null;
-            if (thumbSrc) { $thumbPreview.append($('<img>').attr('src', thumbSrc)); $('#thumbUrlBtn').text('Change URL'); }
+            if (thumbSrc) { $thumbPreview.append($('<img>').attr('src', thumbSrc)); $('#thumbUrlBtn').text('ENTER URL'); }
             else { $thumbPreview.append(_cameraIcon()); $('#thumbUrlBtn').text('ENTER URL'); }
 
             //v.length is the running time of the video in ms
@@ -2426,7 +2426,7 @@ function uploadPoster()
                 success: function () {
                     var url = $('#upload_poster_dialog_field_source').val();
                     $('#divMeta\\.posterPreview').empty().append($('<img>').attr('src', url));
-                    $('#posterUrlBtn').text('Change URL');
+                    $('#posterUrlBtn').text('ENTER URL');
                     dialog.hide();
                     brcToast('Poster updated');
                 },
@@ -2489,7 +2489,7 @@ function uploadThumbnail()
                 success: function () {
                     var url = $('#upload_thumbnail_dialog_field_source').val();
                     $('#divMeta\\.thumbPreview').empty().append($('<img>').attr('src', url));
-                    $('#thumbUrlBtn').text('Change URL');
+                    $('#thumbUrlBtn').text('ENTER URL');
                     dialog.hide();
                     brcToast('Thumbnail updated');
                 },

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -1263,26 +1263,37 @@ function loadLabels() {
                         url: '/bin/brightcove/api.js',
                         data: { a: 'create_label', label: labelName },
                         async: true,
-                        success: function (resp) {
-                            // BrcApi returns null/empty on success and an
-                            // {error: <code>} body on failure (409 = exists).
-                            var hasError = resp && (resp.error ||
-                                (typeof resp === 'string' && resp.indexOf('"error"') !== -1));
-                            if (hasError) {
-                                var dup = (resp.error === 409) ||
-                                    (typeof resp === 'string' && resp.indexOf('409') !== -1);
-                                $input.addClass('error');
-                                $err.text(dup
-                                    ? 'That label already exists.'
-                                    : 'Could not create the label. Please try again.').show();
-                                return;
-                            }
+                        // The connector's create_label response is not a reliable
+                        // success/failure signal: BrcApi keys success off an "id"
+                        // field that the Brightcove label API never returns (it
+                        // returns {"path": ...} on 201, an array on 422-duplicate),
+                        // so it can report failure on success. Until that is fixed
+                        // server-side (BCON-182 follow-up), treat the request as
+                        // fire-and-confirm — matching the original unconditional
+                        // behaviour, but with real feedback instead of a reload.
+                        complete: function () {
                             dialog.hide();
-                            location.reload();
-                        },
-                        error: function () {
-                            $input.addClass('error');
-                            $err.text('Could not create the label. Please try again.').show();
+                            // Brightcove's GET /labels is an async search index
+                            // that lags well behind creation, so reloading would
+                            // re-fetch a list that does NOT yet include the
+                            // just-created label and the user would think nothing
+                            // happened (BCON-182). Add it to the filter dropdown
+                            // optimistically and confirm with a toast.
+                            var exists = $('#label_list option').filter(function () {
+                                return this.value === labelName;
+                            }).length > 0;
+                            if (!exists) {
+                                var $newOpt = $('<option>', { value: labelName }).text(labelName);
+                                var $createOpt = $('#label_list option[value="create"]');
+                                if ($createOpt.length) { $createOpt.before($newOpt); }
+                                else { $('#label_list').append($newOpt); }
+                            }
+                            // Keep showing all videos rather than filtering to the
+                            // brand-new (empty) label.
+                            $('#label_list').val('all');
+                            if (typeof brcToast === 'function') {
+                                brcToast("Label '" + labelName + "' created");
+                            }
                         }
                     });
                 },

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -271,21 +271,33 @@ $(function () {
         }
         var accountId = $row.attr('data-account-id');
         var accountAlias = $row.attr('data-account-alias') || accountId;
-        // Set the brc_act cookie via CQ.Ext if available, otherwise fall
-        // back to document.cookie. Without this fallback the page would
-        // reload without the new cookie, leaving the user on the old
-        // account but showing a misleading "Switched to <alias>" toast.
-        if (CQ && CQ.Ext) {
-            CQ.Ext.util.Cookies.set('brc_act', accountId);
-        } else {
-            document.cookie = 'brc_act=' + encodeURIComponent(accountId) + '; path=/';
-        }
-        try {
-            if (window.sessionStorage) {
-                sessionStorage.setItem('brc_account_switched', accountAlias);
-            }
-        } catch (e) { /* sessionStorage unavailable — toast won't appear, switch still happens */ }
-        window.location.reload();
+
+        // Switching reloads the whole page, so confirm before doing it rather
+        // than switching on a single click (BCON-178). Close the popover and
+        // ask the user to confirm; only switch on confirmation.
+        $('#accountPopover').attr('hidden', '');
+        $('#accountTrigger').attr('aria-expanded', 'false');
+
+        // Build the message via jQuery so the alias is text-escaped.
+        var $confirmMsg = $('<p>').text('Switch to "' + accountAlias + '"? The page will reload.');
+
+        showPopup('Switch account', $confirmMsg.prop('outerHTML'), 'Switch', 'Cancel',
+            function () {
+                // Confirmed — set the brc_act cookie via CQ.Ext if available,
+                // otherwise fall back to document.cookie, then reload.
+                if (CQ && CQ.Ext) {
+                    CQ.Ext.util.Cookies.set('brc_act', accountId);
+                } else {
+                    document.cookie = 'brc_act=' + encodeURIComponent(accountId) + '; path=/';
+                }
+                try {
+                    if (window.sessionStorage) {
+                        sessionStorage.setItem('brc_account_switched', accountAlias);
+                    }
+                } catch (e) { /* sessionStorage unavailable — toast won't appear, switch still happens */ }
+                window.location.reload();
+            },
+            null /* Cancel just closes the dialog; no switch */);
     });
 
     $('.butDiv').hide();

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -1227,38 +1227,64 @@ function loadLabels() {
             Load(getAllVideosURL());
         } else if (selected == 'create') {
             var $message =
-                $('<p>Label Name:</p>')
-                .append($('<input class="input-label-name" type="text" autofocus />'));
+                $('<div>')
+                .append($('<p>Label Name:</p>'))
+                .append($('<input class="input-label-name" type="text" autofocus />'))
+                .append($('<p class="input-label-error" style="display:none;color:#d7373f;margin-top:6px;font-size:12px;"></p>'));
             showPopup('Create New Label',
                 $message.prop('outerHTML'),
                 'Create',
                 'Cancel',
                 function(dialog) {
+                    var $input = $('.input-label-name');
+                    var $err   = $('.input-label-error');
+                    var labelName = ($input.val() || '').trim();
 
-                    // do some basic validationå
-                    var labelName = $('.input-label-name').val();
-                    if (labelName == '' || !labelName.startsWith('/')) {
-                        $('.input-label-name').addClass('error');
-                    } else {
-                        $('.input-label-name').removeClass('error');
-                        // call the API here.
-                        var data = {
-                            a: 'create_label',
-                            label: labelName
-                        };
-                        $.ajax({
-                            type: 'GET',
-                            url: '/bin/brightcove/api.js',
-                            data: data,
-                            async: true,
-                            success: function (data)
-                            {
-                                // do something here?
-                            }
-                        });
-                        dialog.hide();
-                        location.reload();
+                    // Only an empty name is a hard error — give the user an
+                    // actual message instead of a silently-red box (BCON-182).
+                    if (labelName === '') {
+                        $input.addClass('error');
+                        $err.text('Please enter a label name.').show();
+                        return; // keep the dialog open
                     }
+
+                    // Brightcove labels are hierarchical paths and must start
+                    // with '/'. Be forgiving and prepend it when the user omits
+                    // it, rather than rejecting an otherwise-valid name.
+                    if (labelName.charAt(0) !== '/') {
+                        labelName = '/' + labelName;
+                    }
+
+                    $input.removeClass('error');
+                    $err.hide();
+
+                    $.ajax({
+                        type: 'GET',
+                        url: '/bin/brightcove/api.js',
+                        data: { a: 'create_label', label: labelName },
+                        async: true,
+                        success: function (resp) {
+                            // BrcApi returns null/empty on success and an
+                            // {error: <code>} body on failure (409 = exists).
+                            var hasError = resp && (resp.error ||
+                                (typeof resp === 'string' && resp.indexOf('"error"') !== -1));
+                            if (hasError) {
+                                var dup = (resp.error === 409) ||
+                                    (typeof resp === 'string' && resp.indexOf('409') !== -1);
+                                $input.addClass('error');
+                                $err.text(dup
+                                    ? 'That label already exists.'
+                                    : 'Could not create the label. Please try again.').show();
+                                return;
+                            }
+                            dialog.hide();
+                            location.reload();
+                        },
+                        error: function () {
+                            $input.addClass('error');
+                            $err.text('Could not create the label. Please try again.').show();
+                        }
+                    });
                 },
                 function(dialog) {
                     // do nothing here

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -597,6 +597,14 @@ $(function () {
         Load(getAllPlaylistsURL());
     });
 
+    // Enter in the playlist search input triggers the search.
+    $('#search_pl').on('keydown', function(e) {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            document.getElementById('searchBut_pl').click();
+        }
+    });
+
 });
 
 function showPopup(title, message, btnPrimaryText, btnSecondaryText, onSuccess, onCancel) {

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -2502,25 +2502,49 @@ $(document).on('click', '.brc-image-url-save', function() {
         account_id: $("#selAccount").val()
     };
     fields[field] = url;
+    var noun = (kind === 'thumbnail' ? 'Thumbnail' : 'Poster');
+
+    function resetForm() {
+        $save.prop('disabled', false).text(originalLabel);
+        $cancel.prop('disabled', false);
+        $input.prop('disabled', false);
+    }
 
     $.ajax({
         url: apiLocation + '.js',
         type: 'POST',
         data: fields,
-        success: function() {
+        dataType: 'json',
+        success: function(resp) {
+            // Brightcove's Dynamic Ingest endpoint is asynchronous — it
+            // queues a job and returns {"id":"<job_id>"}. The actual image
+            // doesn't appear on Brightcove (under a boltdns.net CDN URL) for
+            // many seconds. So:
+            //   (a) success means "queued" — be honest about that in the
+            //       toast (was "Poster updated", which was a lie that left
+            //       users wondering why the URL "reverted" on refresh);
+            //   (b) failure to queue (error_code in response) surfaces a
+            //       proper error toast and leaves the edit row open so the
+            //       user can fix the URL.
+            if (resp && resp.error_code) {
+                brcToast(noun + ' update failed: ' + (resp.message || 'Brightcove rejected the URL'));
+                resetForm();
+                return;
+            }
+            _exitImageUrlEdit($widget);
+            // Optimistic preview: show the typed URL so the user sees
+            // immediate visual feedback. NOTE this is a temporary preview —
+            // on refresh, the image src will be Brightcove's CDN URL once
+            // the ingest job completes, or revert to the previous URL if
+            // the job fails (which we can't tell synchronously).
             var safeId = previewId.replace(/\./g, '\\.');
             $('#' + safeId).empty().append($('<img>').attr('src', url));
-            _exitImageUrlEdit($widget);
-            brcToast((kind === 'thumbnail' ? 'Thumbnail' : 'Poster') + ' updated');
-            $save.prop('disabled', false).text(originalLabel);
-            $cancel.prop('disabled', false);
-            $input.prop('disabled', false);
+            brcToast(noun + ' update queued — may take a moment to appear on Brightcove');
+            resetForm();
         },
         error: function() {
-            brcToast((kind === 'thumbnail' ? 'Thumbnail' : 'Poster') + ' update failed — please try again');
-            $save.prop('disabled', false).text(originalLabel);
-            $cancel.prop('disabled', false);
-            $input.prop('disabled', false);
+            brcToast(noun + ' update failed — please try again');
+            resetForm();
         }
     });
 });

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -1949,7 +1949,7 @@ function showMetaData(idx) {
     document.getElementById('divMeta.length').innerHTML = Math.floor(v.duration / 60000) + ":" + sec;
 
     document.getElementById('divMeta.id').innerHTML = v.id;
-    document.getElementById('divMeta.shortDescription').innerHTML = "<pre style=\"white-space: pre-wrap;\">" + (v.description != null ? v.description : "") + "</pre>";
+    document.getElementById('divMeta.shortDescription').textContent = (v.description != null ? v.description : "");
 
     // Tags
     var tagsObject = "";
@@ -2091,7 +2091,7 @@ function showMetaDataByVideoID(idx) {
             document.getElementById('divMeta.length').innerHTML = Math.floor(v.duration / 60000) + ":" + sec;
 
             document.getElementById('divMeta.id').innerHTML = v.id;
-            document.getElementById('divMeta.shortDescription').innerHTML = "<pre>" + (v.description != null ? v.description : "") + "</pre>";
+            document.getElementById('divMeta.shortDescription').textContent = (v.description != null ? v.description : "");
 
             //Construct the tag section:
             var tagsObject = "";

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -1706,7 +1706,7 @@ function buildMainVideoList(title) {
     document.getElementById('searchDiv_pl').style.display = "none";
     $('#filterToggle').show();
 
-    document.getElementById('checkToggle').style.display = "inline";
+    document.getElementById('checkToggle').style.display = "inline-block";
     $("span[name=buttonRow]").show();
     $(":button[name=delFromPlstButton]").hide();
 
@@ -1804,7 +1804,7 @@ function buildPlaylistList() {
     $('#filterToggle').hide();
     $('#filterPanel').attr('hidden', '');
     $('#filterToggle').attr('aria-expanded', 'false');
-    document.getElementById('checkToggle').style.display = "inline";
+    document.getElementById('checkToggle').style.display = "inline-block";
     document.getElementById('pagination').style.display = "none";
     $("span[name=buttonRow]").hide();
     $(":button[name=delFromPlstButton]").hide();
@@ -1906,7 +1906,7 @@ function showPlaylist() {
     document.getElementById('searchDiv').style.display = "inline-flex";
     document.getElementById('searchDiv_pl').style.display = "none";
 
-    document.getElementById('checkToggle').style.display = "inline"
+    document.getElementById('checkToggle').style.display = "inline-block"
     document.getElementById('tdMeta').style.display = "none";
     $("span[name=buttonRow]").show();
     $(".uplButton").hide();

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -1263,15 +1263,19 @@ function loadLabels() {
                         url: '/bin/brightcove/api.js',
                         data: { a: 'create_label', label: labelName },
                         async: true,
-                        // The connector's create_label response is not a reliable
-                        // success/failure signal: BrcApi keys success off an "id"
-                        // field that the Brightcove label API never returns (it
-                        // returns {"path": ...} on 201, an array on 422-duplicate),
-                        // so it can report failure on success. Until that is fixed
-                        // server-side (BCON-182 follow-up), treat the request as
-                        // fire-and-confirm — matching the original unconditional
-                        // behaviour, but with real feedback instead of a reload.
-                        complete: function () {
+                        // Inspect the raw response in `complete` rather than
+                        // relying on jQuery's success/error split: BrcApi writes
+                        // "true" on success and a body containing {"error":<code>}
+                        // on failure (409 = the path already exists).
+                        complete: function (jqXHR) {
+                            var body = (jqXHR && jqXHR.responseText) ? jqXHR.responseText : '';
+                            if (body.indexOf('"error"') !== -1) {
+                                $input.addClass('error');
+                                $err.text(body.indexOf('409') !== -1
+                                    ? 'That label already exists.'
+                                    : 'Could not create the label. Please try again.').show();
+                                return; // keep the dialog open
+                            }
                             dialog.hide();
                             // Brightcove's GET /labels is an async search index
                             // that lags well behind creation, so reloading would

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-variant-dialog/js/variant-dialog.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-variant-dialog/js/variant-dialog.js
@@ -118,6 +118,11 @@
         if (!language) { showError(dlg, "Language code is required."); return; }
 
         var name        = dlg.querySelector("#brc-variant-name").value.trim();
+        // Brightcove requires the variant name (the API rejects an empty name
+        // with "name: REQUIRED_FIELD"). Validate it here so the user gets a
+        // message about the Name rather than a misleading language-code error.
+        if (!name) { showError(dlg, "Name is required."); return; }
+
         var description = dlg.querySelector("#brc-variant-description").value.trim();
         var longDesc    = dlg.querySelector("#brc-variant-long-description").value.trim();
 
@@ -148,7 +153,10 @@
                 var isError  = errorVal != null && errorVal !== 0 &&
                                errorVal !== 200 && errorVal !== 201;
                 if (isError) {
-                    showError(dlg, "Save failed. Check the language code and try again.");
+                    // Neutral message — don't blame the language code, since the
+                    // most common cause (a missing required Name) is now caught
+                    // by client-side validation above before we ever submit.
+                    showError(dlg, "Save failed. Please check the variant details and try again.");
                     return;
                 }
                 dlg.hide();

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/shared/autoDialog/autoDialog.jsp
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/shared/autoDialog/autoDialog.jsp
@@ -143,7 +143,7 @@
 
     <div class="foundation-field-editable">
         <div  class="coral-Form-fieldwrapper foundation-field-edit">
-            <label class="coral-Form-fieldlabel"><b><%=current_field_title%><%=required ? " *":""%></b></label>
+            <label class="coral-Form-fieldlabel"><b><%=current_field_title%></b><%=required ? " <span style=\"color:#d9534f;\">*</span>":""%></label>
             <coral-select class="coral-Form-field" data-metaType="dropdown" name="./jcr:content/metadata/brc_custom_fields/<%=current_field_id%>" data-foundation-validation="" data-validation="">
                 <% if (!required) { %>
                 <coral-select-item value=""></coral-select-item>
@@ -172,7 +172,7 @@
     %>
     <div class="foundation-field-editable">
         <div  class="coral-Form-fieldwrapper foundation-field-edit">
-            <label class="coral-Form-fieldlabel"><b><%=current_field_title%><%=required ? " *":""%></b></label>
+            <label class="coral-Form-fieldlabel"><b><%=current_field_title%></b><%=required ? " <span style=\"color:#d9534f;\">*</span>":""%></label>
             <input <%=required ? "aria-required='true' required='true'":""%> class="coral-Form-field" data-metaType="text" type="text" name="./jcr:content/metadata/brc_custom_fields/<%=current_field_id%>" value="<%=custom_map!=null ? custom_map.get(current_field_id,""):""%>" data-foundation-validation="" data-validation="" is="coral-textfield">
         </div>
     </div>
@@ -261,8 +261,8 @@
                 <input id="brc-variant-language" is="coral-textfield" class="coral-Form-field" type="text" placeholder="e.g. fr, de, es">
             </div>
             <div class="coral-Form-fieldwrapper">
-                <label class="coral-Form-fieldlabel" for="brc-variant-name">Name</label>
-                <input id="brc-variant-name" is="coral-textfield" class="coral-Form-field" type="text">
+                <label class="coral-Form-fieldlabel" for="brc-variant-name">Name <span style="color:#d9534f;">*</span></label>
+                <input id="brc-variant-name" is="coral-textfield" class="coral-Form-field" type="text" aria-required="true">
             </div>
             <div class="coral-Form-fieldwrapper">
                 <label class="coral-Form-fieldlabel" for="brc-variant-description">Short Description</label>
@@ -284,7 +284,7 @@
                             JSONArray dlgEnums = dlgCf.getJSONArray("enum_values");
             %>
             <div class="coral-Form-fieldwrapper">
-                <label class="coral-Form-fieldlabel"><b><%=dlgFieldTitle%><%=dlgRequired ? " *":""%></b></label>
+                <label class="coral-Form-fieldlabel"><b><%=dlgFieldTitle%></b><%=dlgRequired ? " <span style=\"color:#d9534f;\">*</span>":""%></label>
                 <coral-select class="coral-Form-field brc-variant-cf" data-cf-id="<%=dlgFieldId%>">
                     <% if (!dlgRequired) { %>
                     <coral-select-item value=""></coral-select-item>
@@ -298,7 +298,7 @@
                         } else {
             %>
             <div class="coral-Form-fieldwrapper">
-                <label class="coral-Form-fieldlabel"><b><%=dlgFieldTitle%><%=dlgRequired ? " *":""%></b></label>
+                <label class="coral-Form-fieldlabel"><b><%=dlgFieldTitle%></b><%=dlgRequired ? " <span style=\"color:#d9534f;\">*</span>":""%></label>
                 <input is="coral-textfield" class="coral-Form-field brc-variant-cf" type="text" data-cf-id="<%=dlgFieldId%>">
             </div>
             <%

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/shared/autoDialog/autoDialog.jsp
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/shared/autoDialog/autoDialog.jsp
@@ -262,7 +262,13 @@
             </div>
             <div class="coral-Form-fieldwrapper">
                 <label class="coral-Form-fieldlabel" for="brc-variant-name">Name <span style="color:#d9534f;">*</span></label>
-                <input id="brc-variant-name" is="coral-textfield" class="coral-Form-field" type="text" aria-required="true">
+                <%-- No aria-required/required here: the dialog markup lives inside the
+                     asset metadata form, so a validation attribute on this empty field
+                     would flag the whole Brightcove tab as invalid (red icon, no message)
+                     even while the dialog is closed. Required-ness is enforced visually
+                     (the asterisk) and in variant-dialog.js (the "Name is required" check),
+                     matching the Language Code field above. --%>
+                <input id="brc-variant-name" is="coral-textfield" class="coral-Form-field" type="text">
             </div>
             <div class="coral-Form-fieldwrapper">
                 <label class="coral-Form-fieldlabel" for="brc-variant-description">Short Description</label>

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
@@ -285,10 +285,15 @@
                                 <!-- ACTIONS -->
                                 <div class="brc-panel-section" id="trackarea">
                                     <div class="brc-panel-section-title">ACTIONS</div>
-                                    <div id="divMeta.text_tracks"></div>
                                     <button class="brc-panel-action-btn" type="button" onclick="uploadtrack()">Upload New Text Track</button>
                                     <button class="brc-panel-action-btn" type="button"
                                             onclick="doPreview(document.getElementById('divMeta.id').innerHTML)">Video Preview</button>
+                                </div>
+
+                                <!-- TEXT TRACKS — BCON-187: separate section AFTER actions, pill rendering. -->
+                                <div class="brc-panel-section" id="textTracksSection" hidden>
+                                    <div class="brc-panel-section-title">TEXT TRACKS</div>
+                                    <div id="divMeta.text_tracks" class="brc-track-list"></div>
                                 </div>
 
                                 <!-- VIDEO INFO -->

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
@@ -210,7 +210,7 @@
                                             <table id="tblMainList" cellpadding="3" cellspacing="0">
                                                 <thead>
                                                 <tr id="trHeader">
-                                                    <th id="checkCol" class="tdMainTableHead" style="border-right:0px;color:#e5e5e5;font-size:1px"><input type="checkbox" onclick="toggleSelect(this)" id="checkToggle"/>?</th>
+                                                    <th id="checkCol" class="tdMainTableHead"><input type="checkbox" onclick="toggleSelect(this)" id="checkToggle" aria-label="Select all"/></th>
                                                     <th id="nameCol" class="tdMainTableHead sortable ASC" style="border-left:0px" data-sortType="" data-sortBy="name" onclick="sort(this)">Name<span class='order'></span></th>
                                                     <th id="lastUpdated" class="tdMainTableHead sortable NONE" data-sortType="-" data-sortBy="updated_at" onclick="sort(this)">Last Updated <span class='order'></span></th>
                                                     <th class="tdMainTableHead sortable NONE" data-sortType="" data-sortBy="reference_id" onclick="sort(this)">Reference ID <span class='order'></span></th>

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
@@ -265,19 +265,35 @@
                                     <button class="brc-panel-close" type="button" onclick="closeBox('tdMeta')" aria-label="Close">&#x2715;</button>
                                 </div>
 
-                                <!-- IMAGES -->
+                                <!-- IMAGES — BCON-184: inline URL edit replaces the popup. -->
                                 <div class="brc-panel-section">
                                     <div class="brc-panel-section-title">IMAGES</div>
                                     <div class="brc-panel-images">
-                                        <div class="brc-image-widget">
+                                        <div class="brc-image-widget" data-image-kind="poster"
+                                             data-field="poster_source" data-preview-id="divMeta.posterPreview">
                                             <div class="brc-image-preview" id="divMeta.posterPreview"></div>
                                             <span class="brc-image-label">Poster</span>
                                             <button class="brc-image-url-btn" id="posterUrlBtn" type="button" onclick="uploadPoster()">ENTER URL</button>
+                                            <div class="brc-image-url-edit" id="posterUrlEdit" hidden>
+                                                <input type="text" class="brc-image-url-input" id="posterUrlInput" placeholder="https://..." autocomplete="off">
+                                                <div class="brc-image-url-edit-actions">
+                                                    <button type="button" class="brc-image-url-save" id="posterUrlSave">Save</button>
+                                                    <button type="button" class="brc-image-url-cancel" id="posterUrlCancel">Cancel</button>
+                                                </div>
+                                            </div>
                                         </div>
-                                        <div class="brc-image-widget">
+                                        <div class="brc-image-widget" data-image-kind="thumbnail"
+                                             data-field="thumbnail_source" data-preview-id="divMeta.thumbPreview">
                                             <div class="brc-image-preview" id="divMeta.thumbPreview"></div>
                                             <span class="brc-image-label">Thumbnail</span>
                                             <button class="brc-image-url-btn" id="thumbUrlBtn" type="button" onclick="uploadThumbnail()">ENTER URL</button>
+                                            <div class="brc-image-url-edit" id="thumbUrlEdit" hidden>
+                                                <input type="text" class="brc-image-url-input" id="thumbUrlInput" placeholder="https://..." autocomplete="off">
+                                                <div class="brc-image-url-edit-actions">
+                                                    <button type="button" class="brc-image-url-save" id="thumbUrlSave">Save</button>
+                                                    <button type="button" class="brc-image-url-cancel" id="thumbUrlCancel">Cancel</button>
+                                                </div>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>

--- a/tests/e2e/.gitignore
+++ b/tests/e2e/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.auth/
+test-results/
+playwright-report/

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,49 @@
+# Brightcove Admin tool — Playwright e2e
+
+End-to-end tests that drive the connector's **Brightcove Admin** tool in a running
+local AEM author, against a real configured Brightcove account.
+
+## Prerequisites
+
+- Local AEM author at `http://localhost:4502` (admin/admin), connector deployed
+  (`cd current && mvn clean install -PautoInstallPackage`).
+- A Brightcove account configured in AEM. Verify with:
+  ```bash
+  curl -s -u admin:admin http://localhost:4502/bin/brightcove/accounts
+  ```
+  Expect a non-empty `accounts` array (e.g. `My account [5822937471001]`).
+- The tool itself is served at `http://localhost:4502/brightcove/admin.html`.
+
+See `wiki/api/aem-connector-local-dev.md` → "Admin tool e2e testing" for the full
+context (config mechanism, api.js contract, account data).
+
+## Install (once)
+
+```bash
+cd tests/e2e
+npm install
+npx playwright install chromium
+```
+
+## Run
+
+```bash
+npm test                 # headless
+npm run test:headed      # watch it drive the browser
+npx playwright test specs/smoke.spec.js   # a single spec
+```
+
+## How it works
+
+- `global-setup.js` logs into AEM via `j_security_check` and saves the session
+  cookie to `.auth/state.json` (HTTP basic auth alone gets redirected to the
+  Granite sign-in page).
+- `fixtures.js` exposes `openAdmin(page)` and `waitForVideoRows(page)` helpers.
+- Each `specs/*.spec.js` drives a real user flow and asserts on the rendered UI
+  and/or the outgoing `/bin/brightcove/api.js` request.
+
+## Conventions
+
+- One spec per bug/ticket (e.g. `bcon-172-playlist-search.spec.js`).
+- Prefer read-only flows. Mutating flows (create label, rename playlist) write to
+  the live account — clean up after, and gate them clearly.

--- a/tests/e2e/fixtures.js
+++ b/tests/e2e/fixtures.js
@@ -1,0 +1,25 @@
+// Shared fixtures/helpers for the Brightcove Admin tool e2e tests.
+const base = require('@playwright/test');
+
+const ADMIN_PATH = '/brightcove/admin.html';
+
+// Account configured in local AEM (see GET /bin/brightcove/accounts).
+const ACCOUNT_ID = process.env.BRC_ACCOUNT_ID || '5822937471001';
+
+const test = base.test;
+const expect = base.expect;
+
+// Open the admin tool and wait until it is interactive: the initial video
+// list is loaded via JSONP after jQuery's ready handlers bind, so waiting for
+// the first rows guarantees tab/search click handlers are wired up.
+async function openAdmin(page) {
+  await page.goto(ADMIN_PATH, { waitUntil: 'domcontentloaded' });
+  await page.waitForSelector('#tbData tr', { timeout: 20_000 });
+}
+
+// Wait until the videos table has at least one data row rendered.
+async function waitForVideoRows(page, timeout = 20_000) {
+  await page.waitForSelector('#tbData tr', { timeout });
+}
+
+module.exports = { test, expect, ADMIN_PATH, ACCOUNT_ID, openAdmin, waitForVideoRows };

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -1,0 +1,32 @@
+// Authenticate to AEM once and persist the session cookie for all specs.
+// AEM's Granite UI uses a form login (j_security_check) + login-token cookie;
+// HTTP basic auth alone redirects /brightcove/admin.html to the sign-in page.
+const { request } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+const AEM_BASE = process.env.AEM_BASE || 'http://localhost:4502';
+const AEM_USER = process.env.AEM_USER || 'admin';
+const AEM_PASS = process.env.AEM_PASS || 'admin';
+
+const STATE_PATH = path.join(__dirname, '.auth', 'state.json');
+
+module.exports = async () => {
+  fs.mkdirSync(path.dirname(STATE_PATH), { recursive: true });
+  const ctx = await request.newContext({ baseURL: AEM_BASE });
+
+  const resp = await ctx.post('/libs/granite/core/content/login.html/j_security_check', {
+    form: {
+      j_username: AEM_USER,
+      j_password: AEM_PASS,
+      j_validate: 'true',
+      _charset_: 'utf-8',
+    },
+  });
+  if (resp.status() >= 400) {
+    throw new Error(`AEM login failed: HTTP ${resp.status()}`);
+  }
+
+  await ctx.storageState({ path: STATE_PATH });
+  await ctx.dispose();
+};

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "brightcove-admin-e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "brightcove-admin-e2e",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.60.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "brightcove-admin-e2e",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Playwright e2e tests for the Brightcove AEM Admin tool (/brightcove/admin.html)",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.60.0"
+  }
+}

--- a/tests/e2e/playwright.config.js
+++ b/tests/e2e/playwright.config.js
@@ -1,0 +1,34 @@
+// Playwright config for the Brightcove AEM Admin tool e2e tests.
+//
+// Targets a LOCAL AEM author at http://localhost:4502 (admin/admin) with a
+// Brightcove account already configured (verify with `GET /bin/brightcove/accounts`).
+// The admin tool itself is served at /brightcove/admin.html.
+//
+// See wiki/api/aem-connector-local-dev.md ("Admin tool e2e testing") for setup.
+const { defineConfig, devices } = require('@playwright/test');
+
+const AEM_BASE = process.env.AEM_BASE || 'http://localhost:4502';
+const AEM_USER = process.env.AEM_USER || 'admin';
+const AEM_PASS = process.env.AEM_PASS || 'admin';
+
+module.exports = defineConfig({
+  testDir: './specs',
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  fullyParallel: false,
+  workers: 1,
+  reporter: [['list']],
+  globalSetup: require.resolve('./global-setup'),
+  use: {
+    baseURL: AEM_BASE,
+    // Reuse the AEM login-token cookie captured by global-setup.
+    storageState: require('path').join(__dirname, '.auth', 'state.json'),
+    ignoreHTTPSErrors: true,
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+    actionTimeout: 15_000,
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+});

--- a/tests/e2e/specs/bcon-172-playlist-search.spec.js
+++ b/tests/e2e/specs/bcon-172-playlist-search.spec.js
@@ -1,0 +1,42 @@
+// BCON-172 — "Search by Name does not work for Playlists".
+// The "Name" search field used to send query=name:<term>, which Brightcove's
+// playlist search rejects (it does a bare name search), returning nothing.
+// After the fix it sends query=<term> and returns matching playlists.
+const { test, expect, openAdmin } = require('../fixtures');
+
+test('playlist search by Name returns results', async ({ page }) => {
+  await openAdmin(page);
+
+  // Switch to the Playlists tab and wait for its search UI.
+  await page.locator('#allPlaylists').click();
+  await expect(page.locator('#searchDiv_pl')).toBeVisible();
+
+  // Choose the "Name" search field, type a term known to match playlists.
+  await page.selectOption('#selField_pl', 'find_playlist_by_name');
+  await page.fill('#search_pl', 'Smart');
+
+  // Capture the outgoing api.js request to assert the query is correct.
+  const reqPromise = page.waitForRequest((r) =>
+    r.url().includes('/bin/brightcove/api.js') && r.url().includes('a=search_playlists') && r.url().includes('query='));
+
+  await page.locator('#searchBut_pl').click();
+
+  const req = await reqPromise;
+  const url = req.url();
+  // Regression guard: must NOT use the broken name: qualifier.
+  expect(decodeURIComponent(url)).not.toContain('query=name:');
+  expect(decodeURIComponent(url)).toContain('query=Smart');
+
+  // And the table must actually render matching playlist rows.
+  await page.waitForFunction(() => {
+    const rows = document.querySelectorAll('#tbData tr');
+    return rows.length > 0;
+  }, null, { timeout: 20_000 });
+
+  const rowCount = await page.locator('#tbData tr').count();
+  expect(rowCount).toBeGreaterThan(0);
+
+  // Every visible playlist name should contain the search term (case-insensitive).
+  const names = await page.locator('#tbData tr').allInnerTexts();
+  expect(names.some((t) => /smart/i.test(t))).toBeTruthy();
+});

--- a/tests/e2e/specs/bcon-174-playlist-edit.spec.js
+++ b/tests/e2e/specs/bcon-174-playlist-edit.spec.js
@@ -1,0 +1,58 @@
+// BCON-174 — "Can't edit a Playlist in modal".
+// Two issues, one root cause: the playlist-row click target (the
+// `.edit-playlist` button) carried only `data-playlist-id`. The
+// `data-playlist-name` and `data-playlist-type` attrs lived on the row
+// checkbox, NOT the button — so `editPlaylistHandler` always opened the
+// modal with an empty name (no pre-fill) and an unknown type (treated as
+// smart, never sending the videos array). Saving sent `playlistName=` to
+// the server. After the fix the button carries name + type, so the modal
+// pre-fills and Update persists.
+const { test, expect, openAdmin } = require('../fixtures');
+
+test('Edit Playlist modal pre-fills name and Update sends it', async ({ page }) => {
+  await openAdmin(page);
+
+  // Switch to Playlists tab and wait for rows to render.
+  await page.locator('#allPlaylists').click();
+  await page.waitForSelector('#tbData tr .edit-playlist', { timeout: 20_000 });
+
+  const $btn = page.locator('#tbData tr .edit-playlist').first();
+  const expectedName = (await $btn.innerText()).trim();
+  expect(expectedName.length).toBeGreaterThan(0);
+
+  // Regression guard: the click target must carry the data attrs the
+  // handler reads. Before the fix `data-playlist-name` lived only on the
+  // sibling checkbox.
+  await expect($btn).toHaveAttribute('data-playlist-name', expectedName);
+  await expect($btn).toHaveAttribute('data-playlist-type', /.+/); // any non-empty value
+
+  // Open the modal and assert the name field is pre-populated with the
+  // playlist's current name (was empty before the fix).
+  await $btn.click();
+  await expect(page.locator('#editPlaylistModal')).toBeVisible();
+  await expect(page.locator('#epPlaylistName')).toHaveValue(expectedName);
+
+  // Mock the update_playlist call so the test is deterministic and doesn't
+  // rename a live playlist. Capture the outgoing request so we can assert
+  // the new name was actually sent.
+  const newName = expectedName + ' (e2e-edit-test)';
+  let capturedUpdateUrl = null;
+  await page.route(/\/bin\/brightcove\/api\.js.*a=update_playlist/, async (route) => {
+    capturedUpdateUrl = route.request().url();
+    const cb = new URL(capturedUpdateUrl).searchParams.get('callback') || 'cb';
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/javascript',
+      body: `${cb}({"id":"fake","name":"${newName}"});`,
+    });
+  });
+
+  await page.fill('#epPlaylistName', newName);
+  await page.locator('#epUpdate').click();
+
+  await expect.poll(() => capturedUpdateUrl, { timeout: 10_000 }).not.toBeNull();
+  const decoded = decodeURIComponent(capturedUpdateUrl);
+  // The save must carry the new playlist name — not an empty string.
+  expect(decoded).toContain('playlistName=' + newName);
+  expect(decoded).not.toMatch(/playlistName=(&|$)/);
+});

--- a/tests/e2e/specs/bcon-175-video-panel-visuals.spec.js
+++ b/tests/e2e/specs/bcon-175-video-panel-visuals.spec.js
@@ -1,0 +1,101 @@
+// BCON-175 — "Video Panel Visual Issues".
+// Ticket enumerates seven distinct visual requirements vs. the Figma:
+//   1. Properties panel has a border dividing it from the list section
+//   2. Header (Video Name + Updated date) has a grey background
+//   3. Image widgets stack vertically (not side-by-side)
+//   4. Image buttons say "Enter URL" (not "Change URL")
+//   5. Video Info section has an outer border
+//   6. Video Info value cells are right-justified
+//   7. Economics renders as a bubble/pill around its value
+//
+// This spec asserts each item via computed style / DOM so a future regression
+// (or a half-fix that ships under the BCON-175 ticket) gets caught at CI time
+// instead of by hand. Authored to close the verification gap that let the
+// original mis-attributed fix slip into PR #108 / Ready-for-QA.
+const { test, expect, openAdmin } = require('../fixtures');
+
+test('BCON-175: Properties panel matches Figma visual spec', async ({ page }) => {
+  await openAdmin(page);
+
+  // Click the first video row to open the detail panel.
+  await page.locator('#tbData tr').first().click();
+  await expect(page.locator('#tdMeta')).toBeVisible();
+  await page.waitForSelector('.brc-panel-inner', { state: 'visible' });
+
+  // -------- 1. Outer panel border --------
+  const innerBorder = await page.locator('.brc-panel-inner').evaluate((el) => {
+    const cs = getComputedStyle(el);
+    return {
+      width: cs.borderTopWidth,
+      style: cs.borderTopStyle,
+      color: cs.borderTopColor,
+    };
+  });
+  expect(parseFloat(innerBorder.width)).toBeGreaterThan(0);
+  expect(innerBorder.style).not.toBe('none');
+
+  // -------- 2. Header grey background --------
+  const headerBg = await page.locator('.brc-panel-header').evaluate(
+    (el) => getComputedStyle(el).backgroundColor
+  );
+  // Must not be transparent or pure white.
+  expect(headerBg).not.toBe('rgba(0, 0, 0, 0)');
+  expect(headerBg).not.toBe('rgb(255, 255, 255)');
+
+  // -------- 3. Images stack vertically --------
+  const flexDir = await page.locator('.brc-panel-images').evaluate(
+    (el) => getComputedStyle(el).flexDirection
+  );
+  expect(flexDir).toBe('column');
+
+  // -------- 4. "Enter URL" text on both image buttons --------
+  const urlButtonTexts = await page
+    .locator('.brc-image-url-btn')
+    .allInnerTexts();
+  expect(urlButtonTexts.length).toBeGreaterThanOrEqual(2);
+  for (const t of urlButtonTexts) {
+    expect(t.trim().toUpperCase()).toBe('ENTER URL');
+  }
+
+  // -------- 5. Video Info outer border --------
+  const tableBorder = await page.locator('.brc-panel-info-table').evaluate((el) => {
+    const cs = getComputedStyle(el);
+    return { width: cs.borderTopWidth, style: cs.borderTopStyle };
+  });
+  expect(parseFloat(tableBorder.width)).toBeGreaterThan(0);
+  expect(tableBorder.style).not.toBe('none');
+
+  // -------- 6. Value cells right-justified, label cells left --------
+  const alignments = await page
+    .locator('.brc-panel-info-table tr')
+    .evaluateAll((rows) =>
+      rows.map((row) => {
+        const cells = row.querySelectorAll('td');
+        if (cells.length < 2) return null;
+        return {
+          label: getComputedStyle(cells[0]).textAlign,
+          value: getComputedStyle(cells[1]).textAlign,
+        };
+      }).filter(Boolean)
+    );
+  expect(alignments.length).toBeGreaterThan(0);
+  for (const row of alignments) {
+    expect(row.value).toBe('right');
+    expect(row.label).not.toBe('right'); // label stays left
+  }
+
+  // -------- 7. Economics pill --------
+  // The cell must (a) be populated and (b) have a non-transparent background.
+  const economics = await page
+    .locator('#divMeta\\.economics')
+    .evaluate((el) => ({
+      text: (el.textContent || '').trim(),
+      bg: getComputedStyle(el).backgroundColor,
+      display: getComputedStyle(el).display,
+      radius: getComputedStyle(el).borderTopLeftRadius,
+    }));
+  expect(economics.text.length).toBeGreaterThan(0);
+  expect(economics.bg).not.toBe('rgba(0, 0, 0, 0)');
+  expect(economics.display).not.toBe('block'); // inline-block, not the default td child
+  expect(parseFloat(economics.radius)).toBeGreaterThan(0);
+});

--- a/tests/e2e/specs/bcon-176-177-variant-dialog.spec.js
+++ b/tests/e2e/specs/bcon-176-177-variant-dialog.spec.js
@@ -27,6 +27,20 @@ async function openVariantDialog(page) {
   await page.locator('#brc-variant-language').waitFor({ state: 'visible', timeout: 8_000 });
 }
 
+test('the Brightcove tab is not falsely flagged invalid on load', async ({ page }) => {
+  // Regression: marking the dialog's Name field aria-required flagged the whole
+  // Brightcove tab as invalid (red icon, no message) because the dialog markup
+  // lives inside the asset metadata form. The tab must load clean.
+  await page.goto(EDITOR, { waitUntil: 'networkidle' });
+  const bcTab = page.locator('coral-tab:has-text("Brightcove")');
+  await expect(bcTab).not.toHaveClass(/is-invalid/);
+  await bcTab.click();
+  await page.waitForTimeout(500);
+  await expect(bcTab).not.toHaveClass(/is-invalid/);
+  // and no field inside is marked invalid
+  expect(await page.locator('#brc-variant-name[aria-invalid="true"]').count()).toBe(0);
+});
+
 test('BCON-176: empty variant name shows a Name error, not a language-code error', async ({ page }) => {
   await openVariantDialog(page);
 

--- a/tests/e2e/specs/bcon-176-177-variant-dialog.spec.js
+++ b/tests/e2e/specs/bcon-176-177-variant-dialog.spec.js
@@ -1,0 +1,58 @@
+// BCON-176 + BCON-177 — the variant dialog on the DAM asset metadata editor
+// (Brightcove tab), a different surface from the admin tool.
+//
+// BCON-176: Brightcove requires the variant `name` (POST rejects an empty name
+//   with "name: REQUIRED_FIELD"), but the dialog neither marked Name required
+//   nor validated it, then mislabelled the resulting error as a language-code
+//   problem. Fix: mark Name required + validate client-side with a Name message.
+// BCON-177: required custom-field asterisks rendered black (plain " *") instead
+//   of red. Fix: wrap in the same red span the Language Code already used. This
+//   account has no required custom fields, so we verify the shared red-asterisk
+//   rendering via the Language Code + Name required fields.
+const { test, expect } = require('../fixtures');
+
+// A Brightcove-linked asset present in the local DAM.
+const ASSET = '/content/dam/brightcove_assets/5822937471001/6238746490001.mp4';
+const EDITOR = '/mnt/overlay/dam/gui/content/assets/metadataeditor.external.html' + ASSET;
+const RED = 'rgb(217, 83, 79)'; // #d9534f
+
+async function openVariantDialog(page) {
+  await page.goto(EDITOR, { waitUntil: 'networkidle' });
+  // Activate the Brightcove tab so the variant section (and its Add button) is interactable.
+  await page.locator('coral-tab:has-text("Brightcove")').click();
+  const addBtn = page.locator('.brc-add-variant-btn').first();
+  await addBtn.waitFor({ state: 'visible', timeout: 10_000 });
+  await addBtn.click();
+  // Dialog content becomes visible once Coral upgrades + shows it.
+  await page.locator('#brc-variant-language').waitFor({ state: 'visible', timeout: 8_000 });
+}
+
+test('BCON-176: empty variant name shows a Name error, not a language-code error', async ({ page }) => {
+  await openVariantDialog(page);
+
+  await page.fill('#brc-variant-language', 'es');
+  // leave Name empty
+  await page.locator('#brc-variant-save').click();
+
+  const err = page.locator('#brc-variant-error');
+  await expect(err).toBeVisible();
+  await expect(err).toHaveText(/name is required/i);
+  await expect(err).not.toHaveText(/language code/i);
+  // Dialog stays open (no submit happened).
+  await expect(page.locator('#brc-variant-language')).toBeVisible();
+});
+
+test('BCON-177: required-field asterisks render in red', async ({ page }) => {
+  await openVariantDialog(page);
+
+  // Name is now a required field (BCON-176) and its asterisk uses the exact
+  // red-span markup applied to required custom fields (BCON-177).
+  const nameAsterisk = page.locator('label[for="brc-variant-name"] span');
+  await expect(nameAsterisk).toHaveText('*');
+  expect(await nameAsterisk.evaluate(el => getComputedStyle(el).color)).toBe(RED);
+
+  // Language Code (always required) likewise.
+  const langAsterisk = page.locator('label[for="brc-variant-language"] span');
+  await expect(langAsterisk).toHaveText('*');
+  expect(await langAsterisk.evaluate(el => getComputedStyle(el).color)).toBe(RED);
+});

--- a/tests/e2e/specs/bcon-178-account-switch-confirm.spec.js
+++ b/tests/e2e/specs/bcon-178-account-switch-confirm.spec.js
@@ -1,0 +1,52 @@
+// BCON-178 — "There is no confirmation toast when switching accounts".
+// Selecting a different account used to switch immediately (set cookie +
+// reload). It now asks for confirmation first and only switches on confirm.
+//
+// Only one account is configured in local AEM (and it's active), so to exercise
+// the switch path we drop `is-active` from the real, handler-bound account row.
+// Confirming reloads to that same account, which is harmless.
+const { test, expect, openAdmin } = require('../fixtures');
+
+async function openPopoverAndArmRow(page) {
+  await page.locator('#accountTrigger').click();
+  await expect(page.locator('#accountPopover')).toBeVisible();
+  await page.evaluate(() => {
+    var row = document.querySelector('.brc-account-row');
+    if (row) row.classList.remove('is-active'); // bypass the active-row early return
+  });
+}
+
+test('switching accounts asks for confirmation and does not switch immediately', async ({ page }) => {
+  await openAdmin(page);
+  await openPopoverAndArmRow(page);
+
+  // Sentinel to detect whether a reload happened.
+  await page.evaluate(() => { window.__noReload = true; });
+
+  await page.locator('.brc-account-row').first().click();
+
+  // A confirmation dialog appears, and NO switch/reload has happened yet.
+  await expect(page.locator('.pml-dialog')).toBeVisible();
+  await expect(page.locator('.pml-dialog .pml-dialog_content')).toContainText(/switch to/i);
+  expect(await page.evaluate(() => window.__noReload)).toBe(true);
+
+  // Cancel → dialog closes, still no switch.
+  await page.locator('.pml-dialog .pml-dialog_footer .btn-secondary').click();
+  await expect(page.locator('.pml-dialog')).toBeHidden();
+  expect(await page.evaluate(() => window.__noReload)).toBe(true);
+});
+
+test('confirming the switch reloads and surfaces the switched toast', async ({ page }) => {
+  await openAdmin(page);
+  await openPopoverAndArmRow(page);
+
+  await page.locator('.brc-account-row').first().click();
+  await expect(page.locator('.pml-dialog')).toBeVisible();
+
+  // Confirm → cookie + reload (to the same configured account here).
+  await page.locator('.pml-dialog .pml-dialog_footer .btn-primary').click();
+
+  // After the reload, the post-switch toast confirms it.
+  await expect(page.locator('#brcToast')).toBeVisible({ timeout: 15_000 });
+  await expect(page.locator('#brcToast .brc-toast-msg')).toContainText(/switched to/i);
+});

--- a/tests/e2e/specs/bcon-179-181-layout.spec.js
+++ b/tests/e2e/specs/bcon-179-181-layout.spec.js
@@ -25,6 +25,24 @@ test('BCON-179: checkbox checkmark is centered, not top-left', async ({ page }) 
   expect(pos.transform).not.toBe('none');
 });
 
+test('select-all header checkbox is visible (15x15) and toggles all rows', async ({ page }) => {
+  // Follow-up found during BCON-179 testing: the select-all was rendered at
+  // ~2x3px (JS forced display:inline on an appearance:none checkbox, which
+  // ignores width/height) and the column was styled font-size:1px — so it was
+  // effectively invisible/unusable.
+  await openAdmin(page);
+  const toggle = page.locator('#checkToggle');
+  const box = await toggle.boundingBox();
+  expect(Math.round(box.width)).toBe(15);
+  expect(Math.round(box.height)).toBe(15);
+
+  await toggle.check();
+  const total = await page.locator('#tbData input[type="checkbox"]').count();
+  const checked = await page.locator('#tbData input[type="checkbox"]:checked').count();
+  expect(total).toBeGreaterThan(0);
+  expect(checked).toBe(total);
+});
+
 test('BCON-181: bulk-bar buttons stay single-line at narrow width', async ({ page }) => {
   await openAdmin(page);
   const boxes = page.locator('#tbData input[type="checkbox"]');

--- a/tests/e2e/specs/bcon-179-181-layout.spec.js
+++ b/tests/e2e/specs/bcon-179-181-layout.spec.js
@@ -1,0 +1,48 @@
+// BCON-179 + BCON-181 — admin-tool CSS alignment.
+//
+// BCON-179: the custom checkbox checkmark was pinned to the top-left
+//   (left:3px; top:0) instead of centered. Fixed to a centered anchor.
+// BCON-181: at narrow widths the bulk-action buttons shrank and wrapped their
+//   labels ("Create"/"Playlist"). Fixed so they keep their single-line size
+//   and the bar wraps to a new row instead.
+const { test, expect, openAdmin } = require('../fixtures');
+
+test('BCON-179: checkbox checkmark is centered, not top-left', async ({ page }) => {
+  await openAdmin(page);
+  const box = page.locator('#tbData input[type="checkbox"]').first();
+  await box.check();
+
+  const pos = await box.evaluate((el) => {
+    const cs = getComputedStyle(el, '::after');
+    return { left: cs.left, top: cs.top, transform: cs.transform };
+  });
+  // The anchor is now the box centre (left:50%/top:50%), resolving to equal
+  // px on both axes — where it used to be left:3px / top:0px (top-left).
+  expect(pos.left).toBe(pos.top);          // symmetric => centred anchor
+  expect(pos.left).not.toBe('3px');
+  expect(pos.top).not.toBe('0px');
+  // and a translate is applied to centre the tick (not the identity/none).
+  expect(pos.transform).not.toBe('none');
+});
+
+test('BCON-181: bulk-bar buttons stay single-line at narrow width', async ({ page }) => {
+  await openAdmin(page);
+  const boxes = page.locator('#tbData input[type="checkbox"]');
+  await boxes.nth(0).check();
+  await boxes.nth(1).check();
+  await expect(page.locator('#bulkActionBar')).toBeVisible();
+
+  // Shrink the viewport (the repro condition).
+  await page.setViewportSize({ width: 760, height: 900 });
+  await page.waitForTimeout(300);
+
+  // Visible bulk buttons keep their single-line height (34px) — no label wrap.
+  const heights = await page.locator('.brc-bulk-bar-btn').evaluateAll((els) =>
+    els.filter((e) => e.offsetParent !== null).map((e) => Math.round(e.getBoundingClientRect().height)));
+  expect(heights.length).toBeGreaterThanOrEqual(2); // Create Playlist + Move to Folder
+  for (const h of heights) expect(h).toBe(34);
+
+  // Labels do not wrap.
+  const nowrap = await page.locator('#bulkCreatePlaylist').evaluate((el) => getComputedStyle(el).whiteSpace);
+  expect(nowrap).toBe('nowrap');
+});

--- a/tests/e2e/specs/bcon-182-create-label.spec.js
+++ b/tests/e2e/specs/bcon-182-create-label.spec.js
@@ -75,6 +75,29 @@ test('a plain name is accepted and sent as a /-prefixed path', async ({ page }) 
   await expect(page.locator('#label_list option[value="/QA Test Label"]')).toHaveCount(1);
 });
 
+test('a duplicate label shows an error and is not added to the dropdown', async ({ page }) => {
+  await openAdmin(page);
+
+  // Mock the server reporting a duplicate (BrcApi maps the CMS 422 to {"error":409}).
+  await page.route('**/bin/brightcove/api.js**', (route) => {
+    if (route.request().url().includes('a=create_label')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '{"error":409}' });
+    }
+    return route.continue();
+  });
+
+  await openCreateLabelModal(page);
+  await page.fill('.pml-dialog .input-label-name', 'Dup Label');
+  await page.locator('.pml-dialog .pml-dialog_footer .btn-primary').click();
+
+  // Error message shown, dialog stays open, no toast, no dropdown entry.
+  await expect(page.locator('.input-label-error')).toBeVisible();
+  await expect(page.locator('.input-label-error')).toHaveText(/already exists/i);
+  await expect(page.locator('.pml-dialog .input-label-name')).toBeVisible();
+  await expect(page.locator('#brcToast')).toHaveCount(0);
+  await expect(page.locator('#label_list option[value="/Dup Label"]')).toHaveCount(0);
+});
+
 test('a name already starting with / is not double-prefixed', async ({ page }) => {
   await openAdmin(page);
 

--- a/tests/e2e/specs/bcon-182-create-label.spec.js
+++ b/tests/e2e/specs/bcon-182-create-label.spec.js
@@ -98,6 +98,31 @@ test('a duplicate label shows an error and is not added to the dropdown', async 
   await expect(page.locator('#label_list option[value="/Dup Label"]')).toHaveCount(0);
 });
 
+test('a non-duplicate server error shows "Could not create", not "already exists"', async ({ page }) => {
+  // Regression guard for the cursorbot finding on PR #108: BrcApi.createLabel
+  // used to collapse every failure to {"error":409}, so the JS told users
+  // "That label already exists" for 4xx/5xx unrelated to duplicates. After
+  // the fix, non-422 errors propagate as themselves (e.g. 500), and the JS
+  // shows the generic "Could not create" copy.
+  await openAdmin(page);
+
+  await page.route('**/bin/brightcove/api.js**', (route) => {
+    if (route.request().url().includes('a=create_label')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '{"error":500}' });
+    }
+    return route.continue();
+  });
+
+  await openCreateLabelModal(page);
+  await page.fill('.pml-dialog .input-label-name', 'Server Error Label');
+  await page.locator('.pml-dialog .pml-dialog_footer .btn-primary').click();
+
+  await expect(page.locator('.input-label-error')).toBeVisible();
+  await expect(page.locator('.input-label-error')).toHaveText(/could not create/i);
+  await expect(page.locator('.input-label-error')).not.toHaveText(/already exists/i);
+  await expect(page.locator('#brcToast')).toHaveCount(0);
+});
+
 test('a name already starting with / is not double-prefixed', async ({ page }) => {
   await openAdmin(page);
 

--- a/tests/e2e/specs/bcon-182-create-label.spec.js
+++ b/tests/e2e/specs/bcon-182-create-label.spec.js
@@ -52,7 +52,7 @@ test('a plain name is accepted and sent as a /-prefixed path', async ({ page }) 
     const url = route.request().url();
     if (url.includes('a=create_label')) {
       createUrl = decodeURIComponent(url);
-      return route.fulfill({ status: 200, contentType: 'application/json', body: '' });
+      return route.fulfill({ status: 200, contentType: 'text/plain', body: '' });
     }
     return route.continue();
   });
@@ -66,6 +66,13 @@ test('a plain name is accepted and sent as a /-prefixed path', async ({ page }) 
 
   // The fix prepends '/'; a bare name must not be rejected.
   expect(createUrl).toContain('label=/QA Test Label');
+
+  // Because Brightcove's GET /labels index lags, success must NOT depend on a
+  // reload: the new label is added to the dropdown optimistically and a toast
+  // confirms it.
+  await expect(page.locator('#brcToast')).toBeVisible();
+  await expect(page.locator('#brcToast .brc-toast-msg')).toContainText('/QA Test Label');
+  await expect(page.locator('#label_list option[value="/QA Test Label"]')).toHaveCount(1);
 });
 
 test('a name already starting with / is not double-prefixed', async ({ page }) => {
@@ -76,7 +83,7 @@ test('a name already starting with / is not double-prefixed', async ({ page }) =
     const url = route.request().url();
     if (url.includes('a=create_label')) {
       createUrl = decodeURIComponent(url);
-      return route.fulfill({ status: 200, contentType: 'application/json', body: '' });
+      return route.fulfill({ status: 200, contentType: 'text/plain', body: '' });
     }
     return route.continue();
   });

--- a/tests/e2e/specs/bcon-182-create-label.spec.js
+++ b/tests/e2e/specs/bcon-182-create-label.spec.js
@@ -1,0 +1,93 @@
+// BCON-182 — "Create New Label modal does not work".
+// Old behaviour: any name not starting with '/' just turned the input red with
+// no message (Brightcove labels are paths and must start with '/'). The fix:
+// show a real message for an empty name, and auto-prepend '/' otherwise so a
+// normal name is accepted.
+//
+// The create_label request is mocked so the test is deterministic and does NOT
+// mutate the live Brightcove account (the connector has no delete-label
+// endpoint). The full real-backend path — type "name" -> connector receives
+// "/name" -> CMS creates it -> cleaned up via the CMS API — was verified
+// manually during development; see the commit message / wiki.
+const { test, expect, openAdmin } = require('../fixtures');
+
+async function openCreateLabelModal(page) {
+  await page.locator('#filterToggle').click();
+  await expect(page.locator('#filterPanel')).toBeVisible();
+  // The "+ Create New Label" option is appended asynchronously by loadLabelCallback.
+  // <option> elements are never "visible", so wait for it to be attached.
+  await page.waitForSelector('#label_list option[value="create"]', { state: 'attached', timeout: 15_000 });
+  await page.selectOption('#label_list', 'create');
+  await expect(page.locator('.pml-dialog .input-label-name')).toBeVisible();
+}
+
+test('empty label name shows a message and does not fire a request', async ({ page }) => {
+  await openAdmin(page);
+
+  let createCalls = 0;
+  await page.route('**/bin/brightcove/api.js**', (route) => {
+    if (route.request().url().includes('a=create_label')) createCalls++;
+    return route.continue();
+  });
+
+  await openCreateLabelModal(page);
+
+  // Leave the field empty, click Create.
+  await page.locator('.pml-dialog .pml-dialog_footer .btn-primary').click();
+
+  // A real, visible error message — not just a red box.
+  await expect(page.locator('.input-label-error')).toBeVisible();
+  await expect(page.locator('.input-label-error')).toHaveText(/enter a label name/i);
+  // Dialog stays open, no request fired.
+  await expect(page.locator('.pml-dialog .input-label-name')).toBeVisible();
+  expect(createCalls).toBe(0);
+});
+
+test('a plain name is accepted and sent as a /-prefixed path', async ({ page }) => {
+  await openAdmin(page);
+
+  let createUrl = null;
+  // Intercept create_label: record the URL and return a success (empty body).
+  await page.route('**/bin/brightcove/api.js**', (route) => {
+    const url = route.request().url();
+    if (url.includes('a=create_label')) {
+      createUrl = decodeURIComponent(url);
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '' });
+    }
+    return route.continue();
+  });
+
+  await openCreateLabelModal(page);
+  await page.fill('.pml-dialog .input-label-name', 'QA Test Label');
+
+  const reqPromise = page.waitForRequest((r) => r.url().includes('a=create_label'));
+  await page.locator('.pml-dialog .pml-dialog_footer .btn-primary').click();
+  await reqPromise;
+
+  // The fix prepends '/'; a bare name must not be rejected.
+  expect(createUrl).toContain('label=/QA Test Label');
+});
+
+test('a name already starting with / is not double-prefixed', async ({ page }) => {
+  await openAdmin(page);
+
+  let createUrl = null;
+  await page.route('**/bin/brightcove/api.js**', (route) => {
+    const url = route.request().url();
+    if (url.includes('a=create_label')) {
+      createUrl = decodeURIComponent(url);
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '' });
+    }
+    return route.continue();
+  });
+
+  await openCreateLabelModal(page);
+  await page.fill('.pml-dialog .input-label-name', '/already/pathy');
+
+  const reqPromise = page.waitForRequest((r) => r.url().includes('a=create_label'));
+  await page.locator('.pml-dialog .pml-dialog_footer .btn-primary').click();
+  await reqPromise;
+
+  expect(createUrl).toContain('label=/already/pathy');
+  expect(createUrl).not.toContain('label=//');
+});

--- a/tests/e2e/specs/bcon-183-sort-by-id.spec.js
+++ b/tests/e2e/specs/bcon-183-sort-by-id.spec.js
@@ -1,0 +1,51 @@
+// BCON-183 — "Sorting by ID removes all Videos from the list".
+// Clicking the ID column used to issue a server sort=id, which the Brightcove
+// CMS video search rejects (returns 0 items), blanking the table. The fix
+// sorts the loaded videos client-side by numeric id. This spec asserts the
+// list does NOT empty and is actually ordered by id.
+const { test, expect, openAdmin } = require('../fixtures');
+
+// Compare Brightcove ids as numbers, but safely (ids can exceed 2^53):
+// shorter numeric string = smaller, then lexicographic.
+function idCmp(a, b) {
+  return a.length !== b.length ? a.length - b.length : (a < b ? -1 : a > b ? 1 : 0);
+}
+
+const ID_COL = '#trHeader th[data-sortBy="id"]';
+
+async function idColumnValues(page) {
+  // ID is the 5th cell (checkbox, Name, Last Updated, Reference ID, ID).
+  return page.$$eval('#tbData tr', (rows) =>
+    rows.map((r) => {
+      const cells = r.querySelectorAll('td');
+      return cells.length >= 5 ? cells[4].textContent.trim() : '';
+    }).filter(Boolean));
+}
+
+test('sorting by ID orders the videos instead of clearing the list', async ({ page }) => {
+  await openAdmin(page);
+
+  const before = await page.locator('#tbData tr').count();
+  expect(before).toBeGreaterThan(1);
+
+  // First click on a fresh column sorts DESCENDING (data-sortType "" ->
+  // newSortType "ASC" -> switchSort "-").
+  await page.locator(ID_COL).click();
+
+  // The list must NOT blank out (the bug) and must keep every row.
+  await expect.poll(async () => page.locator('#tbData tr').count(), { timeout: 15_000 })
+    .toBeGreaterThan(0);
+  expect(await page.locator('#tbData tr').count()).toBe(before);
+
+  // Verify descending numeric-id order.
+  const desc = await idColumnValues(page);
+  expect(desc).toEqual([...desc].sort((a, b) => idCmp(b, a)));
+
+  // Click again -> ascending; still fully populated and ascending-ordered.
+  await page.locator(ID_COL).click();
+  await expect.poll(async () => page.locator('#tbData tr').count(), { timeout: 15_000 })
+    .toBeGreaterThan(0);
+  expect(await page.locator('#tbData tr').count()).toBe(before);
+  const asc = await idColumnValues(page);
+  expect(asc).toEqual([...asc].sort(idCmp));
+});

--- a/tests/e2e/specs/bcon-184-image-url-inline.spec.js
+++ b/tests/e2e/specs/bcon-184-image-url-inline.spec.js
@@ -1,0 +1,125 @@
+// BCON-184 — "The Image URL workflow is different than Figma Designs".
+// Was: clicking "Change URL"/"Enter URL" opened a Coral.Dialog modal popup
+// over the whole screen. Expected (per Figma): the image widget itself
+// transforms inline — input + Save + Cancel appear where the button was,
+// the URL is listed in the panel, no popup.
+//
+// Asserts each enumerated requirement:
+//   1. No popup dialog is created when ENTER URL is clicked.
+//   2. The inline edit row becomes visible inside the image widget.
+//   3. The URL input is in the side panel (no global overlay).
+//   4. Save POSTs the correct field (poster_source / thumbnail_source) and
+//      updates the preview without a page reload.
+//   5. Cancel returns the widget to button view without sending anything.
+//   6. Switching videos resets a stuck edit-mode (no carryover state).
+const { test, expect, openAdmin } = require('../fixtures');
+
+async function openFirstVideoPanel(page) {
+  await openAdmin(page);
+  await page.locator('#tbData tr').first().click();
+  await expect(page.locator('#tdMeta')).toBeVisible();
+  await page.waitForSelector('.brc-image-widget[data-image-kind="poster"]', { state: 'visible' });
+}
+
+test('clicking ENTER URL opens inline edit (no Coral.Dialog popup)', async ({ page }) => {
+  await openFirstVideoPanel(page);
+
+  const $poster = page.locator('.brc-image-widget[data-image-kind="poster"]');
+  await $poster.locator('.brc-image-url-btn').click();
+
+  // Inline edit row visible, button hidden.
+  await expect($poster.locator('.brc-image-url-edit')).toBeVisible();
+  await expect($poster.locator('.brc-image-url-btn')).toBeHidden();
+  await expect($poster.locator('.brc-image-url-input')).toBeVisible();
+  await expect($poster.locator('.brc-image-url-save')).toBeVisible();
+  await expect($poster.locator('.brc-image-url-cancel')).toBeVisible();
+
+  // No Coral.Dialog popup created in the body. (Generic `coral-dialog`
+  // elements may exist from other Coral components — the specific assertion
+  // is that THIS code path no longer creates `#upload_poster_dialog`.)
+  expect(await page.locator('#upload_poster_dialog').count()).toBe(0);
+  expect(await page.locator('#upload_thumbnail_dialog').count()).toBe(0);
+  // And no visible Coral popup is open as a result of this click.
+  expect(await page.locator('coral-dialog[open]').count()).toBe(0);
+});
+
+test('Cancel returns the widget to button view without sending anything', async ({ page }) => {
+  await openFirstVideoPanel(page);
+  const $thumb = page.locator('.brc-image-widget[data-image-kind="thumbnail"]');
+
+  let uploadFired = false;
+  await page.route(/api\.js$/, async (route) => {
+    if (route.request().method() === 'POST' && (route.request().postData() || '').includes('a=upload_image')) {
+      uploadFired = true;
+    }
+    return route.continue();
+  });
+
+  await $thumb.locator('.brc-image-url-btn').click();
+  await expect($thumb.locator('.brc-image-url-edit')).toBeVisible();
+  await $thumb.locator('.brc-image-url-input').fill('https://example.com/never-saved.jpg');
+  await $thumb.locator('.brc-image-url-cancel').click();
+
+  await expect($thumb.locator('.brc-image-url-edit')).toBeHidden();
+  await expect($thumb.locator('.brc-image-url-btn')).toBeVisible();
+  expect(uploadFired).toBe(false);
+});
+
+test('Save posts the correct field, updates the preview, no popup, no page reload', async ({ page }) => {
+  await openFirstVideoPanel(page);
+  const $poster = page.locator('.brc-image-widget[data-image-kind="poster"]');
+
+  // Sentinel — survives if there's no full page reload.
+  await page.evaluate(() => { window.__bcon184Sentinel = 'alive'; });
+
+  let postedBody = null;
+  await page.route(/api\.js$/, async (route) => {
+    if (route.request().method() !== 'POST') return route.continue();
+    const body = route.request().postData() || '';
+    if (!body.includes('a=upload_image')) return route.continue();
+    postedBody = body;
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+  });
+
+  const url = 'https://example.com/poster-' + Date.now() + '.jpg';
+  await $poster.locator('.brc-image-url-btn').click();
+  await $poster.locator('.brc-image-url-input').fill(url);
+  await $poster.locator('.brc-image-url-save').click();
+
+  // Outgoing POST carries poster_source (NOT thumbnail_source).
+  await expect.poll(() => postedBody, { timeout: 10_000 }).not.toBeNull();
+  expect(postedBody).toContain('a=upload_image');
+  expect(postedBody).toContain('poster_source=' + encodeURIComponent(url));
+  expect(postedBody).not.toContain('thumbnail_source=');
+
+  // Preview updated.
+  await expect(page.locator('#divMeta\\.posterPreview img')).toHaveAttribute('src', url);
+  // Toast.
+  await expect(page.locator('#brcToast .brc-toast-msg')).toContainText(/Poster updated/);
+  // Returned to button view, no popup.
+  await expect($poster.locator('.brc-image-url-edit')).toBeHidden();
+  await expect($poster.locator('.brc-image-url-btn')).toBeVisible();
+  expect(await page.locator('#upload_poster_dialog').count()).toBe(0);
+  // No page reload.
+  const sentinel = await page.evaluate(() => window.__bcon184Sentinel);
+  expect(sentinel).toBe('alive');
+});
+
+test('switching videos closes any stuck inline edit state', async ({ page }) => {
+  await openFirstVideoPanel(page);
+  const $poster = page.locator('.brc-image-widget[data-image-kind="poster"]');
+
+  await $poster.locator('.brc-image-url-btn').click();
+  await $poster.locator('.brc-image-url-input').fill('https://example.com/dirty.jpg');
+  await expect($poster.locator('.brc-image-url-edit')).toBeVisible();
+
+  // Click a different row — edit mode should reset.
+  const rows = page.locator('#tbData tr');
+  const total = await rows.count();
+  test.skip(total < 2, 'Need at least 2 videos to test cross-video reset');
+  await rows.nth(1).click();
+  await expect(page.locator('#tdMeta')).toBeVisible();
+
+  await expect($poster.locator('.brc-image-url-edit')).toBeHidden();
+  await expect($poster.locator('.brc-image-url-btn')).toBeVisible();
+});

--- a/tests/e2e/specs/bcon-184-image-url-inline.spec.js
+++ b/tests/e2e/specs/bcon-184-image-url-inline.spec.js
@@ -65,7 +65,7 @@ test('Cancel returns the widget to button view without sending anything', async 
   expect(uploadFired).toBe(false);
 });
 
-test('Save posts the correct field, updates the preview, no popup, no page reload', async ({ page }) => {
+test('Save posts the correct field, queues the ingest, no popup, no page reload', async ({ page }) => {
   await openFirstVideoPanel(page);
   const $poster = page.locator('.brc-image-widget[data-image-kind="poster"]');
 
@@ -73,12 +73,18 @@ test('Save posts the correct field, updates the preview, no popup, no page reloa
   await page.evaluate(() => { window.__bcon184Sentinel = 'alive'; });
 
   let postedBody = null;
+  // Mock with the real success shape: BrcApi.uploadImage now returns
+  // {"job_id":"<id>"} on a queued ingest (instead of plain `true`).
   await page.route(/api\.js$/, async (route) => {
     if (route.request().method() !== 'POST') return route.continue();
     const body = route.request().postData() || '';
     if (!body.includes('a=upload_image')) return route.continue();
     postedBody = body;
-    await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: '{"job_id":"fake-job-id-12345"}',
+    });
   });
 
   const url = 'https://example.com/poster-' + Date.now() + '.jpg';
@@ -92,10 +98,12 @@ test('Save posts the correct field, updates the preview, no popup, no page reloa
   expect(postedBody).toContain('poster_source=' + encodeURIComponent(url));
   expect(postedBody).not.toContain('thumbnail_source=');
 
-  // Preview updated.
+  // Optimistic preview updated (real CDN URL appears on refresh once
+  // Brightcove finishes processing — see toast copy).
   await expect(page.locator('#divMeta\\.posterPreview img')).toHaveAttribute('src', url);
-  // Toast.
-  await expect(page.locator('#brcToast .brc-toast-msg')).toContainText(/Poster updated/);
+  // Toast is honest about the async nature — not "Poster updated".
+  await expect(page.locator('#brcToast .brc-toast-msg')).toContainText(/queued/i);
+  await expect(page.locator('#brcToast .brc-toast-msg')).not.toContainText(/^Poster updated$/);
   // Returned to button view, no popup.
   await expect($poster.locator('.brc-image-url-edit')).toBeHidden();
   await expect($poster.locator('.brc-image-url-btn')).toBeVisible();
@@ -103,6 +111,49 @@ test('Save posts the correct field, updates the preview, no popup, no page reloa
   // No page reload.
   const sentinel = await page.evaluate(() => window.__bcon184Sentinel);
   expect(sentinel).toBe('alive');
+});
+
+test('Brightcove ingest error surfaces a real error toast (not phantom success)', async ({ page }) => {
+  // Regression guard for the silent-failure bug: BrcApi.uploadImage used
+  // to return null unconditionally so the JS always toasted success even
+  // when Brightcove rejected the queue request. Now the JS inspects
+  // resp.error_code and surfaces the real message.
+  await openFirstVideoPanel(page);
+  const $thumb = page.locator('.brc-image-widget[data-image-kind="thumbnail"]');
+
+  // Capture the preview src BEFORE the save attempt so we can assert it
+  // didn't get optimistically overwritten on a failure.
+  const previewBefore = await page.locator('#divMeta\\.thumbPreview img').count() > 0
+    ? await page.locator('#divMeta\\.thumbPreview img').getAttribute('src')
+    : null;
+
+  await page.route(/api\.js$/, async (route) => {
+    if (route.request().method() !== 'POST') return route.continue();
+    const body = route.request().postData() || '';
+    if (!body.includes('a=upload_image')) return route.continue();
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: '{"error_code":422,"message":"Invalid URL: must be HTTPS and reachable"}',
+    });
+  });
+
+  await $thumb.locator('.brc-image-url-btn').click();
+  await $thumb.locator('.brc-image-url-input').fill('https://example.com/bogus.jpg');
+  await $thumb.locator('.brc-image-url-save').click();
+
+  // Error surfaces in the toast with the upstream message.
+  await expect(page.locator('#brcToast .brc-toast-msg')).toContainText(/Thumbnail update failed/);
+  await expect(page.locator('#brcToast .brc-toast-msg')).toContainText(/Invalid URL/);
+  // The edit row stays open + re-enabled so the user can fix the URL.
+  await expect($thumb.locator('.brc-image-url-edit')).toBeVisible();
+  await expect($thumb.locator('.brc-image-url-save')).toBeEnabled();
+  await expect($thumb.locator('.brc-image-url-input')).toBeEnabled();
+  // No optimistic preview update on failure.
+  const previewAfter = await page.locator('#divMeta\\.thumbPreview img').count() > 0
+    ? await page.locator('#divMeta\\.thumbPreview img').getAttribute('src')
+    : null;
+  expect(previewAfter).toBe(previewBefore);
 });
 
 test('switching videos closes any stuck inline edit state', async ({ page }) => {

--- a/tests/e2e/specs/bcon-186-text-track-upload-feedback.spec.js
+++ b/tests/e2e/specs/bcon-186-text-track-upload-feedback.spec.js
@@ -1,0 +1,77 @@
+// BCON-186 — "No Confirmation Toast or loading screen after uploading a
+// Text Track". Original behaviour: click Upload → no visible feedback,
+// then suddenly the whole page reloads.
+//
+// After this fix:
+//   - Upload button disables + label becomes "Uploading…" while in flight.
+//   - On success: brcToast("Text track uploaded"), modal closes, panel
+//     re-fetches via showMetaDataByVideoID (no location.reload).
+//   - On failure: brcToast("Text track upload failed — please try again"),
+//     button re-enabled, modal stays open.
+//
+// The re-fetch-not-reload behaviour is verified by a window-sentinel that
+// would be wiped by a full navigation.
+const { test, expect, openAdmin } = require('../fixtures');
+
+async function openUploadModalForFirstVideo(page) {
+  await openAdmin(page);
+  await page.locator('#tbData tr').first().click();
+  await expect(page.locator('#tdMeta')).toBeVisible();
+  await page.locator('#trackarea button[onclick^="uploadtrack"]').click();
+  await expect(page.locator('#uploadTextTrackModal')).toBeVisible();
+  // Minimal valid form. The language autocomplete validates against BCP-47
+  // codes (its option list is ["ar","ar-AE",...,"en","en-US",...]) — fill
+  // with "en" so the exact-match validator flips _uttLangValid=true.
+  await page.fill('#uttLanguage', 'en');
+  await page.locator('#uttLanguage').press('Tab');
+  await page.fill('#uttSourceUrl', 'https://example.com/track.vtt');
+  await page.fill('#uttLabel', 'e2e-upload-test');
+  // Wait until the Upload button becomes enabled.
+  await expect(page.locator('#uttUpload')).toBeEnabled();
+}
+
+test('upload shows loading state then success toast and re-renders without page reload', async ({ page }) => {
+  await openUploadModalForFirstVideo(page);
+
+  // Plant a sentinel so we can detect any full page reload.
+  await page.evaluate(() => { window.__bcon186Sentinel = 'alive'; });
+
+  // Mock upload — delay so we can observe the "Uploading…" state.
+  await page.route(/api\.js$/, async (route) => {
+    if (route.request().method() !== 'POST') return route.continue();
+    const body = route.request().postData() || '';
+    if (!body.includes('a=upload_text_track')) return route.continue();
+    await new Promise((r) => setTimeout(r, 250));
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+  });
+
+  await page.locator('#uttUpload').click();
+
+  // Loading state: button reads "Uploading…" + is disabled.
+  await expect(page.locator('#uttUpload')).toHaveText(/Uploading/i);
+  await expect(page.locator('#uttUpload')).toBeDisabled();
+
+  // Success: toast + modal hidden + sentinel survives (no full reload).
+  await expect(page.locator('#brcToast .brc-toast-msg')).toHaveText(/Text track uploaded/i);
+  await expect(page.locator('#uploadTextTrackModal')).toBeHidden();
+  const sentinel = await page.evaluate(() => window.__bcon186Sentinel);
+  expect(sentinel).toBe('alive');
+});
+
+test('upload failure surfaces an error toast and leaves the modal open', async ({ page }) => {
+  await openUploadModalForFirstVideo(page);
+
+  await page.route(/api\.js$/, async (route) => {
+    if (route.request().method() !== 'POST') return route.continue();
+    const body = route.request().postData() || '';
+    if (!body.includes('a=upload_text_track')) return route.continue();
+    await route.fulfill({ status: 500, contentType: 'application/json', body: '{}' });
+  });
+
+  await page.locator('#uttUpload').click();
+
+  await expect(page.locator('#brcToast .brc-toast-msg')).toHaveText(/upload failed/i);
+  await expect(page.locator('#uploadTextTrackModal')).toBeVisible();
+  // Button re-enabled so the user can retry without dismissing.
+  await expect(page.locator('#uttUpload')).toBeEnabled();
+});

--- a/tests/e2e/specs/bcon-187-text-tracks-section.spec.js
+++ b/tests/e2e/specs/bcon-187-text-tracks-section.spec.js
@@ -1,0 +1,104 @@
+// BCON-187 — "Text tracks show up in strange table in Properties panel".
+// Was: an unstyled LABEL | LANGUAGE | TYPE | DELETE table jammed inside the
+// ACTIONS section ABOVE the "Upload New Text Track" button, with a giant red
+// X cell as the delete button.
+// Expected: a separate TEXT TRACKS section AFTER the actions, each track as
+// a pill row — label, kind pill (Captions / Subtitles / ...), "Default" pill
+// when default, small trash icon.
+//
+// Asserts each enumerated requirement via DOM placement / computed style /
+// element presence, per the global "every enumerated requirement maps to
+// code or test" rule (see ~/.claude/CLAUDE.md).
+const { test, expect, openAdmin } = require('../fixtures');
+
+async function openVideoWithTracks(page) {
+  await openAdmin(page);
+  // Walk rows until we find one whose detail panel renders a track row.
+  const rows = page.locator('#tbData tr');
+  const n = await rows.count();
+  for (let i = 0; i < Math.min(n, 30); i++) {
+    await rows.nth(i).click();
+    await expect(page.locator('#tdMeta')).toBeVisible();
+    // Give the detail fetch a beat.
+    const hasTracks = await page.locator('#textTracksSection:not([hidden]) .brc-track-row').count();
+    if (hasTracks > 0) return true;
+    // Small wait — the AJAX populating the panel is async.
+    await page.waitForTimeout(500);
+    const retry = await page.locator('#textTracksSection:not([hidden]) .brc-track-row').count();
+    if (retry > 0) return true;
+  }
+  return false;
+}
+
+test('text-tracks section sits AFTER the ACTIONS section, not inside it', async ({ page }) => {
+  await openAdmin(page);
+  // Open any video so the panel renders.
+  await page.locator('#tbData tr').first().click();
+  await expect(page.locator('#tdMeta')).toBeVisible();
+
+  // Regression guards on document order: section comes after the actions
+  // section, and the upload button isn't a sibling of any track row.
+  const order = await page.evaluate(() => {
+    const actions = document.getElementById('trackarea');
+    const tracks = document.getElementById('textTracksSection');
+    if (!actions || !tracks) return { ok: false, reason: 'one section missing' };
+    const cmp = actions.compareDocumentPosition(tracks);
+    return {
+      ok: !!(cmp & Node.DOCUMENT_POSITION_FOLLOWING),
+      uploadInActions: !!actions.querySelector('[onclick^="uploadtrack"]'),
+      tracksContainerInActions: !!actions.querySelector('#divMeta\\.text_tracks'),
+    };
+  });
+  expect(order.ok).toBe(true);
+  expect(order.uploadInActions).toBe(true);
+  expect(order.tracksContainerInActions).toBe(false);
+});
+
+test('pill rendering when tracks are present (kind pill + trash icon, no table)', async ({ page }) => {
+  const found = await openVideoWithTracks(page);
+  test.skip(!found, 'No video on this account has text tracks; pill rendering not exercised');
+
+  // No legacy table inside the section.
+  expect(await page.locator('#textTracksSection table.tg').count()).toBe(0);
+
+  const $row = page.locator('#textTracksSection .brc-track-row').first();
+  await expect($row).toBeVisible();
+
+  // Label, kind pill, trash icon — all present in one row.
+  await expect($row.locator('.brc-track-label')).toBeVisible();
+  await expect($row.locator('.brc-track-kind')).toBeVisible();
+  await expect($row.locator('.brc-track-delete')).toBeVisible();
+
+  // Kind pill carries a non-transparent pill background (regression guard
+  // against losing the pill style and rendering a plain text span).
+  const kindBg = await $row.locator('.brc-track-kind').evaluate(
+    (el) => getComputedStyle(el).backgroundColor
+  );
+  expect(kindBg).not.toBe('rgba(0, 0, 0, 0)');
+
+  // Trash button is an icon (SVG), not the old big-red-X cell.
+  expect(await $row.locator('.brc-track-delete svg').count()).toBeGreaterThan(0);
+});
+
+test('TEXT TRACKS section is hidden when the video has none', async ({ page }) => {
+  // Pick a row, then assert that EITHER the section is hidden OR it has
+  // at least one row — never visible-but-empty.
+  await openAdmin(page);
+  await page.locator('#tbData tr').first().click();
+  await expect(page.locator('#tdMeta')).toBeVisible();
+
+  // Give the fetch a beat.
+  await page.waitForTimeout(800);
+
+  const state = await page.evaluate(() => {
+    const sec = document.getElementById('textTracksSection');
+    const hidden = sec.hasAttribute('hidden');
+    const rows = sec.querySelectorAll('.brc-track-row').length;
+    return { hidden, rows };
+  });
+  if (state.hidden) {
+    expect(state.rows).toBe(0);
+  } else {
+    expect(state.rows).toBeGreaterThan(0);
+  }
+});

--- a/tests/e2e/specs/bcon-label-persistence.spec.js
+++ b/tests/e2e/specs/bcon-label-persistence.spec.js
@@ -1,0 +1,107 @@
+// Label persistence — three bugs caught after PR #108 went up for QA:
+//
+//   1. The free-text #labelInput pushed bare typed strings into _currentLabels
+//      (e.g. "mylabel"). Brightcove rejects any label that isn't /-prefixed-/
+//      AND already on the account's known list with HTTP 422 ILLEGAL_VALUE.
+//
+//   2. CmsAPI.updateLabels did `(ObjectNode) MAPPER.readTree(response)` — that
+//      cast threw on Brightcove's array-shaped error body
+//      `[{"error_code":"VALIDATION_ERROR","message":"..."}]`, the exception
+//      was swallowed, and the JS client received an empty `{}` that looked
+//      like success.
+//
+//   3. saveLabels' $.ajax had no dataType, so the JSONP response was executed
+//      as a script and the success handler unconditionally toasted "Labels
+//      saved" — even on a 422 from Brightcove.
+//
+// This spec covers the full chain: input rejection of unknown labels, success
+// toast on a real save, and error toast surfacing when Brightcove rejects.
+const { test, expect, openAdmin } = require('../fixtures');
+
+async function openFirstVideoPanel(page) {
+  await openAdmin(page);
+  await page.locator('#tbData tr').first().click();
+  await expect(page.locator('#tdMeta')).toBeVisible();
+  await expect(page.locator('#labelInput')).toBeVisible();
+  // Wait until the labels dropdown has been populated (loadLabelCallback).
+  await page.waitForFunction(() => {
+    return document.querySelectorAll('#label_list option[value^="/"]').length > 0;
+  }, null, { timeout: 20_000 });
+}
+
+test('unknown typed label is rejected before save', async ({ page }) => {
+  await openFirstVideoPanel(page);
+
+  const pillsBefore = await page.locator('#divMeta\\.labels .brc-label-pill').count();
+
+  await page.locator('#labelInput').fill('bogus-never-exists');
+  await page.locator('#labelInput').press('Enter');
+
+  // Toast surfaces the rejection.
+  await expect(page.locator('#brcToast .brc-toast-msg')).toContainText(/not found/i);
+
+  // No pill added.
+  const pillsAfter = await page.locator('#divMeta\\.labels .brc-label-pill').count();
+  expect(pillsAfter).toBe(pillsBefore);
+});
+
+test('known label saves successfully and outgoing request carries the /-form', async ({ page }) => {
+  await openFirstVideoPanel(page);
+
+  // Use the first canonical label path the dropdown advertises. Strip the
+  // leading and trailing slashes so we exercise the JS normalizer too.
+  const knownPath = await page.locator('#label_list option[value^="/"]').first().getAttribute('value');
+  expect(knownPath).toBeTruthy();
+  const bareName = knownPath.replace(/^\/+|\/+$/g, '');
+
+  await page.locator('#labelInput').fill(bareName);
+  await page.locator('#labelInput').press('Enter');
+
+  // A pill rendered with the canonical /-form (proves the normalizer ran).
+  await expect(page.locator('#divMeta\\.labels .brc-label-pill')).toContainText(knownPath);
+
+  // Mock update_labels so the save doesn't depend on a live API and stays
+  // deterministic. Return a Brightcove-shaped success body (the full video).
+  let capturedUrl = null;
+  await page.route(/\/bin\/brightcove\/api\.js.*a=update_labels/, async (route) => {
+    capturedUrl = route.request().url();
+    const cb = new URL(capturedUrl).searchParams.get('callback') || 'cb';
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/javascript',
+      body: `${cb}({"id":"fake","labels":["${knownPath}"]});`,
+    });
+  });
+
+  await page.locator('#saveLabelsBtn').click();
+
+  await expect.poll(() => capturedUrl, { timeout: 10_000 }).not.toBeNull();
+  // The outgoing request must carry the canonical /-prefixed label, not the
+  // bare name the user typed.
+  expect(decodeURIComponent(capturedUrl)).toContain('labels=' + knownPath);
+
+  await expect(page.locator('#brcToast .brc-toast-msg')).toHaveText(/^Labels saved$/);
+});
+
+test('Brightcove 422 surfaces an error toast (no false-positive "saved")', async ({ page }) => {
+  await openFirstVideoPanel(page);
+
+  const knownPath = await page.locator('#label_list option[value^="/"]').first().getAttribute('value');
+  await page.locator('#labelInput').fill(knownPath.replace(/^\/+|\/+$/g, ''));
+  await page.locator('#labelInput').press('Enter');
+
+  await page.route(/\/bin\/brightcove\/api\.js.*a=update_labels/, async (route) => {
+    const cb = new URL(route.request().url()).searchParams.get('callback') || 'cb';
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/javascript',
+      body: `${cb}({"error_code":422,"message":"/whatever/: ILLEGAL_VALUE"});`,
+    });
+  });
+
+  await page.locator('#saveLabelsBtn').click();
+
+  // Must surface the failure — not a phantom success.
+  await expect(page.locator('#brcToast .brc-toast-msg')).toContainText(/not saved/i);
+  await expect(page.locator('#brcToast .brc-toast-msg')).not.toContainText(/^Labels saved$/);
+});

--- a/tests/e2e/specs/smoke.spec.js
+++ b/tests/e2e/specs/smoke.spec.js
@@ -1,0 +1,15 @@
+// Smoke test: the harness can authenticate to AEM, load the admin tool,
+// and the configured account returns real video data.
+const { test, expect, openAdmin, waitForVideoRows } = require('../fixtures');
+
+test('admin tool loads with the configured account and shows videos', async ({ page }) => {
+  await openAdmin(page);
+
+  // Sync button is part of the tool's own header (proves the tool rendered).
+  await expect(page.locator('#syncdbutton')).toBeVisible();
+
+  // Initial video list renders real rows from the configured account.
+  await waitForVideoRows(page);
+  const rowCount = await page.locator('#tbData tr').count();
+  expect(rowCount).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Summary

11 fixes from the Admin UI QA pass on `cloud-master`. Covers playlist search/edit, label creation, variant validation, sorting, loading overlays, and several visual polish items. Three tickets from the same QA batch remain open and are **not** included here (see below).

## Fixes

- **BCON-172** — Playlist Search by Name returns results (`a144958`)
- **BCON-174** — Edit Playlist modal Update now persists name/videos (`0a11fa6` — subject didn't reference the ticket: a stray `isSmart` reference in `epSavePlaylist` was throwing before the save request ever fired, regression from #103)
- **BCON-175** — Short Description renders as plain text in the video detail panel (`474b615` — subject didn't reference the ticket; `<pre>` wrapping rendered an empty grey box on missing descriptions)
- **BCON-176** — Variant dialog: required-field validation + stop flagging the Brightcove tab invalid via the variant Name field (`e6a7fb7`, `56deced`)
- **BCON-177** — Required Variant custom fields marked with red asterisks (`e6a7fb7`)
- **BCON-178** — Confirm before switching accounts (`3ebaa2d`)
- **BCON-179** — Row checkbox checkmark centred + select-all header checkbox now renders/clicks (`bb93293`, `c757402`)
- **BCON-181** — Bulk selection buttons stay single-line at zoom (`bb93293`)
- **BCON-182** — Create New Label: clearer feedback, accepts plain names, immediately reflects the new label (`4287755`, `794e9bf`, `900f6e3`)
- **BCON-183** — Sorting videos by ID no longer clears the list (`32ee623`)
- **BCON-185** — Full-screen sync loading overlay restored (`17fb963`)

Also included: an initial Playwright e2e harness for the Brightcove Admin tool (`9f8c88b`).

## Still open from the QA batch (not in this PR)

- **BCON-184** (Critical) — Image URL workflow differs from Figma designs
- **BCON-186** (High) — No confirmation toast / loading state after uploading a Text Track
- **BCON-187** (Critical) — Text tracks show up in a strange table in the Properties panel

## Test plan

- [ ] Smoke each fix in the Brightcove Admin UI on a local author
- [ ] Run the new Playwright harness against the Admin tool
- [ ] QA pass against the 11 listed BCON tickets