### PR TITLE
BCON-188: fix ORGINAL->ORIGINAL typo in ServiceUtil rendition log and comment

### DIFF
--- a/current/core/src/main/java/com/coresecure/brightcove/wrapper/sling/ServiceUtil.java
+++ b/current/core/src/main/java/com/coresecure/brightcove/wrapper/sling/ServiceUtil.java
@@ -1093,7 +1093,7 @@ public class ServiceUtil {
         ObjectNode master = JsonNodeFactory.instance.objectNode();
         ValueMap original_map = original_rendition.getProperties();
         Date orig_lastmod_time = original_map.get(JcrConstants.JCR_LASTMODIFIED,new Date(0));
-        LOGGER.trace("ORGINAL RENDITION : [Rendition Last Mod: {}] VS [Last Sync: {} ]"  ,orig_lastmod_time, brc_lastsync_time);
+        LOGGER.trace("ORIGINAL RENDITION : [Rendition Last Mod: {}] VS [Last Sync: {} ]"  ,orig_lastmod_time, brc_lastsync_time);
         ConfigurationGrabber cg = ServiceUtil.getConfigurationGrabber();
         ConfigurationService brcService = cg.getConfigurationService(account_id);
         String ingest_profile = brcService.getIngestProfile();
@@ -1215,7 +1215,7 @@ public class ServiceUtil {
         ObjectNode master = JsonNodeFactory.instance.objectNode();
 
         if (currentVideo.id == null) return false;
-        //ORGINAL RENDITION - REPLACE CHECK -  RENDITION PROCESS
+        //ORIGINAL RENDITION - REPLACE CHECK -  RENDITION PROCESS
         if (original_rendition != null)
         {
             master = setOriginalRendition(original_rendition, brc_lastsync_time, _asset, serviceUtil, currentVideo);


### PR DESCRIPTION
## BCON-188 — fix `ORGINAL` → `ORIGINAL` typo in ServiceUtil

Corrects a misspelling in `ServiceUtil.java`. Both occurrences are
non-functional text (a `LOGGER.trace` message and a `//` comment), so there is
no behavior change.

### Requirement → change map
| Requirement | Change |
|---|---|
| All `ORGINAL` occurrences in `ServiceUtil.java` → `ORIGINAL` | `current/core/.../sling/ServiceUtil.java:1096` — `LOGGER.trace("ORGINAL RENDITION : ...")` → `"ORIGINAL RENDITION : ..."` |
| (same) | `current/core/.../sling/ServiceUtil.java:1218` — `//ORGINAL RENDITION - REPLACE CHECK ...` → `//ORIGINAL RENDITION ...` |
| No behavior change; `mvn test` passes | string/comment only; `core` module `mvn -q -DskipITs test` succeeds (see below) |
| Single-file change | diff touches one file, 2 lines |

Confirmed via `grep` that these are the only two `ORGINAL` occurrences in the file.

### Build verification
- `mvn -q -DskipITs test -pl core` → **BUILD SUCCESS** (the `core` module is the only one touched).
- Note: the repo currently has no unit tests, so `mvn test` validates compilation/build only.
- A full-reactor `mvn test` on a fresh clone fails earlier resolving the `brightcove.ui.apps.structure` zip sibling (content-package zips aren't produced at the `test` phase) — a pre-existing reactor limitation, unrelated to this change.

### LOCAL VERIFICATION REQUIRED (reviewer)
- [ ] Build + deploy to `localhost:4502`: `cd current && mvn clean install -PautoInstallPackage -DskipTests`
- [ ] Confirm `brightcove.core` bundle is **Active** after deploy
- [ ] Exercise a video/rendition sync so the `TRACE` log path executes; confirm the log now reads `ORIGINAL RENDITION : ...`
- [ ] Regression sweep: rendition sync/replace behavior unchanged (string/comment-only edit)
- [ ] Editor/Playwright listener walk on the test page (no component config touched — sanity only)
- [ ] Save → re-read a synced asset; no diff in stored rendition state
