### PR TITLE
fix(BCON-175,BCON-184): video properties panel visual fidelity

### DIFF
--- a/current/all/pom.xml
+++ b/current/all/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.20</version>
+        <version>7.1.21</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/analyse/pom.xml
+++ b/current/analyse/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.20</version>
+        <version>7.1.21</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/core/pom.xml
+++ b/current/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.20</version>
+        <version>7.1.21</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>brightcove.core</artifactId>

--- a/current/it.tests/pom.xml
+++ b/current/it.tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.20</version>
+        <version>7.1.21</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/pom.xml
+++ b/current/pom.xml
@@ -21,7 +21,7 @@
     <groupId>com.coresecure</groupId>
     <artifactId>brightcove</artifactId>
     <packaging>pom</packaging>
-    <version>7.1.20</version>
+    <version>7.1.21</version>
     <description>Brightcove Connector</description>
 
     <modules>

--- a/current/ui.apps.structure/pom.xml
+++ b/current/ui.apps.structure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.20</version>
+        <version>7.1.21</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.apps/pom.xml
+++ b/current/ui.apps/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.20</version>
+        <version>7.1.21</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -2771,8 +2771,10 @@ body.brc-mtf-open {
   top: 0;
   max-height: 100vh;
   overflow-y: auto;
-  /* BCON-175: outer border divides the Properties panel from the list section. */
-  border: 1px solid #e8e6df;
+  /* BCON-175 #3: only a LEFT divider separates the panel from the list. A full
+     border put a stray vertical bar down the panel's right edge (and doubled
+     the left divider); the sections inside carry their own borders. */
+  border-left: 1px solid #e8e6df;
   background: #fff;
 }
 
@@ -2840,9 +2842,15 @@ body.brc-mtf-open {
 .brc-image-widget {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 6px;
+  gap: 8px;
   flex: 1;
+  /* BCON-175 #1 / BCON-184: each image is a white bordered card (the grey
+     placeholder + ENTER URL / inline editor live inside it), per Figma. */
+  background: #fff;
+  border: 1px solid #e8e6df;
+  border-radius: 10px;
+  padding: 12px;
+  box-sizing: border-box;
 }
 
 .brc-image-preview {
@@ -2864,9 +2872,15 @@ body.brc-mtf-open {
   object-fit: cover;
 }
 
-.brc-image-label {
-  font-size: 11px;
+/* BCON-184: the camera icon + label are centered INSIDE the grey placeholder
+   (empty state) per Figma; the external label below is suppressed. */
+.brc-image-placeholder-label {
+  font-size: 12px;
   color: #6b7280;
+}
+
+.brc-image-label {
+  display: none;
 }
 
 .brc-image-url-btn {
@@ -2888,16 +2902,18 @@ body.brc-mtf-open {
   background: #f7f6f2;
 }
 
-/* BCON-184: inline image URL editor (replaces the popup). */
+/* BCON-184: inline image URL editor (replaces the popup).
+   BCON-175 #2: input + Save + Cancel sit on ONE row, per Figma. */
 .brc-image-url-edit {
   display: flex;
-  flex-direction: column;
-  gap: 8px;
-  margin-top: 6px;
+  flex-direction: row;
+  align-items: center;
+  gap: 6px;
 }
 
 .brc-image-url-input {
-  width: 100%;
+  flex: 1 1 auto;
+  min-width: 0;
   border: 1px solid #e8e6df;
   border-radius: 8px;
   padding: 6px 10px;
@@ -2914,15 +2930,16 @@ body.brc-mtf-open {
 
 .brc-image-url-edit-actions {
   display: flex;
+  flex: 0 0 auto;
   gap: 6px;
 }
 
 .brc-image-url-save,
 .brc-image-url-cancel {
-  flex: 1 1 0;
+  flex: 0 0 auto;
   border: 1px solid #e8e6df;
   border-radius: 8px;
-  padding: 6px 10px;
+  padding: 6px 12px;
   font-size: 12px;
   font-family: inherit;
   cursor: pointer;
@@ -2945,8 +2962,10 @@ body.brc-mtf-open {
   cursor: not-allowed;
 }
 
+/* Cancel is a borderless text button in the Figma. */
 .brc-image-url-cancel {
-  background: #fff;
+  background: transparent;
+  border-color: transparent;
   color: #1a1a18;
 }
 
@@ -2995,6 +3014,13 @@ body.brc-mtf-open {
   border-bottom: 1px solid #f0efea;
   font-size: 13px;
   color: #1a1a18;
+  /* BCON-175 #4: vertically center the label + value (the Economics pill was
+     top-justified). Variants can be multi-line — kept top-aligned below. */
+  vertical-align: middle;
+}
+
+/* Variants value can wrap to several lines; align its label to the top. */
+.brc-panel-info-table tr:has(#divMeta\.variants) td {
   vertical-align: top;
 }
 
@@ -3007,8 +3033,10 @@ body.brc-mtf-open {
   text-align: right;
 }
 
-/* BCON-175: Economics renders as a bubble/pill around the value. */
-#divMeta\.economics:not(:empty) {
+/* BCON-175: Economics renders as a bubble/pill around the value. The pill is
+   an inner span (.brc-economics-pill) so the <td> stays a normal table cell —
+   styling the cell itself as inline-block broke the row layout (#4/#5). */
+.brc-economics-pill {
   display: inline-block;
   padding: 2px 10px;
   border-radius: 99px;

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -2025,27 +2025,15 @@ function showMetaData(idx) {
     var modDate = new Date(v.updated_at);
     document.getElementById('divMeta.lastModifiedDate').innerHTML = 'Updated ' + (modDate.getMonth() + 1) + "/" + modDate.getDate() + "/" + modDate.getFullYear();
 
-    // Poster preview
-    var $posterPreview = $('#divMeta\\.posterPreview').empty();
+    // Poster preview (BCON-184/BCON-175: bordered card + in-card label)
     var posterSrc = (v.images && v.images.poster && v.images.poster.src) ? v.images.poster.src : null;
-    if (posterSrc) {
-        $posterPreview.append($('<img>').attr('src', posterSrc));
-        $('#posterUrlBtn').text('ENTER URL');
-    } else {
-        $posterPreview.append(_cameraIcon());
-        $('#posterUrlBtn').text('ENTER URL');
-    }
+    _renderImagePreview($('#divMeta\\.posterPreview'), posterSrc, 'Poster');
+    $('#posterUrlBtn').text('ENTER URL');
 
     // Thumbnail preview
-    var $thumbPreview = $('#divMeta\\.thumbPreview').empty();
     var thumbSrc = v.thumbnailURL || null;
-    if (thumbSrc) {
-        $thumbPreview.append($('<img>').attr('src', thumbSrc));
-        $('#thumbUrlBtn').text('ENTER URL');
-    } else {
-        $thumbPreview.append(_cameraIcon());
-        $('#thumbUrlBtn').text('ENTER URL');
-    }
+    _renderImagePreview($('#divMeta\\.thumbPreview'), thumbSrc, 'Thumbnail');
+    $('#thumbUrlBtn').text('ENTER URL');
 
     // Duration
     var sec = String((Math.floor(v.duration * .001)) % 60);
@@ -2079,7 +2067,7 @@ function showMetaData(idx) {
     document.getElementById('divMeta.linkURL').href = linkURL;
     document.getElementById('divMeta.linkText').innerHTML = linkText;
 
-    document.getElementById('divMeta.economics').innerHTML = v.economics;
+    _setEconomics(v.economics);
 
     modDate = new Date(v.published_at);
     document.getElementById('divMeta.publishedDate').innerHTML = (modDate.getMonth() + 1) + "/" + modDate.getDate() + "/" + modDate.getFullYear();
@@ -2172,17 +2160,15 @@ function showMetaDataByVideoID(idx) {
             var modDate = new Date(v.updated_at);
             document.getElementById('divMeta.lastModifiedDate').innerHTML = 'Updated ' + (modDate.getMonth() + 1) + "/" + modDate.getDate() + "/" + modDate.getFullYear();
 
-            // Poster preview
-            var $posterPreview = $('#divMeta\\.posterPreview').empty();
+            // Poster preview (BCON-184/BCON-175: bordered card + in-card label)
             var posterSrc = (v.images && v.images.poster && v.images.poster.src) ? v.images.poster.src : null;
-            if (posterSrc) { $posterPreview.append($('<img>').attr('src', posterSrc)); $('#posterUrlBtn').text('ENTER URL'); }
-            else { $posterPreview.append(_cameraIcon()); $('#posterUrlBtn').text('ENTER URL'); }
+            _renderImagePreview($('#divMeta\\.posterPreview'), posterSrc, 'Poster');
+            $('#posterUrlBtn').text('ENTER URL');
 
             // Thumbnail preview
-            var $thumbPreview = $('#divMeta\\.thumbPreview').empty();
             var thumbSrc = (v.images && v.images.thumbnail && v.images.thumbnail.src) ? v.images.thumbnail.src : null;
-            if (thumbSrc) { $thumbPreview.append($('<img>').attr('src', thumbSrc)); $('#thumbUrlBtn').text('ENTER URL'); }
-            else { $thumbPreview.append(_cameraIcon()); $('#thumbUrlBtn').text('ENTER URL'); }
+            _renderImagePreview($('#divMeta\\.thumbPreview'), thumbSrc, 'Thumbnail');
+            $('#thumbUrlBtn').text('ENTER URL');
 
             //v.length is the running time of the video in ms
             var sec = String((Math.floor(v.duration * .001)) % 60); //The number of seconds not part of a whole minute
@@ -2213,7 +2199,7 @@ function showMetaDataByVideoID(idx) {
 
             document.getElementById('divMeta.linkURL').href = linkURL;
             document.getElementById('divMeta.linkText').innerHTML = linkText;
-            document.getElementById('divMeta.economics').innerHTML = v.economics;
+            _setEconomics(v.economics);
 
             modDate = new Date(v.published_at);
             document.getElementById('divMeta.publishedDate').innerHTML = (modDate.getMonth() + 1) + "/" + modDate.getDate() + "/" + modDate.getFullYear();
@@ -2259,6 +2245,38 @@ function _cameraIcon() {
         '<path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" stroke="#6b7280" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>' +
         '<circle cx="12" cy="13" r="4" stroke="#6b7280" stroke-width="2"/>' +
         '</svg>');
+}
+
+// BCON-175 #4/#5: render Economics as a pill INSIDE the cell (an inner span),
+// not by turning the <td> itself into an inline-block — doing the latter pulls
+// the cell out of the table layout, left-aligning the pill and breaking the
+// row divider. The span keeps the cell a normal right-aligned table cell.
+function _setEconomics(val) {
+    var el = document.getElementById('divMeta.economics');
+    if (!el) return;
+    el.innerHTML = '';
+    if (val) {
+        var span = document.createElement('span');
+        span.className = 'brc-economics-pill';
+        span.textContent = val;
+        el.appendChild(span);
+    }
+}
+
+// BCON-184/BCON-175: render an image preview. When a src exists the image
+// fills the card; when empty, the camera icon + label are centered INSIDE the
+// grey placeholder (per Figma) and the widget is marked .is-empty.
+function _renderImagePreview($preview, src, labelText) {
+    $preview.empty();
+    var $widget = $preview.closest('.brc-image-widget');
+    if (src) {
+        $preview.append($('<img>').attr('src', src));
+        $widget.removeClass('is-empty');
+    } else {
+        $preview.append(_cameraIcon())
+                .append($('<span class="brc-image-placeholder-label">').text(labelText));
+        $widget.addClass('is-empty');
+    }
 }
 
 function renderLabelPills() {

--- a/current/ui.config/pom.xml
+++ b/current/ui.config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.20</version>
+        <version>7.1.21</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.content/pom.xml
+++ b/current/ui.content/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.20</version>
+        <version>7.1.21</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.tests/pom.xml
+++ b/current/ui.tests/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.20</version>
+        <version>7.1.21</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
## Summary

Visual-fidelity pass on the Brightcove Admin video **properties panel**, addressing the open QA feedback on BCON-184 (reopened) and BCON-175 (5 new issues from QA). Every change was rendered against the Figma and screenshot-verified before committing.

## Changes
| Ticket | Issue | Fix |
|---|---|---|
| BCON-184 / BCON-175 #1 | no border around images | each image is a white bordered card; camera icon + label centered **inside** the grey placeholder (empty state); external label removed |
| BCON-175 #2 | Save/Cancel not on the URL field's line | inline editor is one row: input + Save + Cancel; Cancel is borderless |
| BCON-175 #3 | stray vertical bar on panel's right edge | panel uses a **left-only** divider from the list (was a full border) |
| BCON-175 #4 | Economics pill top-justified | info-table cells vertically centered (Variants stays top-aligned) |
| BCON-175 #5 | row divider didn't span the table | Economics pill moved to an **inner span** — the cell was `display:inline-block`, which pulled the `<td>` out of the table layout |

BCON-177 (red asterisk), BCON-179 (centered checkmark), BCON-181 (bulk buttons at narrow width), and BCON-187 (text-tracks pill section) were re-verified by rendering — their existing fixes hold.

## Verification
Built and installed to a local AEM author; drove the panel with Playwright and compared each state to the Figma (image cards, empty placeholder, inline editor, Video Info / Economics, panel right edge, text tracks). Version bumped 7.1.20 → **7.1.21** so the build installs as a distinct version.