### PR TITLE
fix: page-number select styling + text-track pill colours

### DIFF
--- a/current/all/pom.xml
+++ b/current/all/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.21</version>
+        <version>7.1.22</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/analyse/pom.xml
+++ b/current/analyse/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.21</version>
+        <version>7.1.22</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/core/pom.xml
+++ b/current/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.21</version>
+        <version>7.1.22</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>brightcove.core</artifactId>

--- a/current/it.tests/pom.xml
+++ b/current/it.tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.21</version>
+        <version>7.1.22</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/pom.xml
+++ b/current/pom.xml
@@ -21,7 +21,7 @@
     <groupId>com.coresecure</groupId>
     <artifactId>brightcove</artifactId>
     <packaging>pom</packaging>
-    <version>7.1.21</version>
+    <version>7.1.22</version>
     <description>Brightcove Connector</description>
 
     <modules>

--- a/current/ui.apps.structure/pom.xml
+++ b/current/ui.apps.structure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.21</version>
+        <version>7.1.22</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.apps/pom.xml
+++ b/current/ui.apps/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.21</version>
+        <version>7.1.22</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -1002,6 +1002,26 @@ div.delConfPop {
 .pageDiv {
   float: right;
   padding: 5px 3px 5px 0px;
+  /* Align the "Page Number:" label with its now-styled select. */
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: #1a1a18;
+}
+
+/* Style the page-number dropdown to match the design-system selects
+   (.brc-filter-select) — it was a default native <select>. */
+.pageDiv select {
+  height: 32px;
+  padding: 0 10px;
+  border: 1px solid #e8e6df;
+  border-radius: 8px;
+  background: #fff;
+  font-family: inherit;
+  font-size: 13px;
+  color: #1a1a18;
+  cursor: pointer;
 }
 
 .butDiv {
@@ -3143,14 +3163,16 @@ body.brc-mtf-open {
   color: #3730a3;
 }
 
+/* BCON-187: match the Figma/mock — Captions + Default are olive/green,
+   Subtitles is grey (was red + blue). */
 .brc-track-kind--captions {
-  background: #fee2e2;
-  color: #991b1b;
+  background: #eaf0da;
+  color: #586b2a;
 }
 
 .brc-track-kind--subtitles {
-  background: #dbeafe;
-  color: #1e3a8a;
+  background: #f0efea;
+  color: #6b7280;
 }
 
 .brc-track-kind--descriptions {

--- a/current/ui.config/pom.xml
+++ b/current/ui.config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.21</version>
+        <version>7.1.22</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.content/pom.xml
+++ b/current/ui.content/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.21</version>
+        <version>7.1.22</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.tests/pom.xml
+++ b/current/ui.tests/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.21</version>
+        <version>7.1.22</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Visual-polish follow-ups from the page-by-page render sweep (verified by screenshot against the design):

- **Page Number select** — was a default native `<select>`; styled to match the design-system selects (Labels/Folder) and aligned its label.
- **Text-track pills (BCON-187)** — Captions → olive, Subtitles → grey (were red + blue) to match the mock; Default stays green.

Version → **7.1.22**.