### PR TITLE
fix(BCON-174): refresh playlist list after rename

### DIFF
--- a/current/all/pom.xml
+++ b/current/all/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.22</version>
+        <version>7.1.23</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/analyse/pom.xml
+++ b/current/analyse/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.22</version>
+        <version>7.1.23</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/core/pom.xml
+++ b/current/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.22</version>
+        <version>7.1.23</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>brightcove.core</artifactId>

--- a/current/it.tests/pom.xml
+++ b/current/it.tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.22</version>
+        <version>7.1.23</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/pom.xml
+++ b/current/pom.xml
@@ -21,7 +21,7 @@
     <groupId>com.coresecure</groupId>
     <artifactId>brightcove</artifactId>
     <packaging>pom</packaging>
-    <version>7.1.22</version>
+    <version>7.1.23</version>
     <description>Brightcove Connector</description>
 
     <modules>

--- a/current/ui.apps.structure/pom.xml
+++ b/current/ui.apps.structure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.22</version>
+        <version>7.1.23</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.apps/pom.xml
+++ b/current/ui.apps/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.22</version>
+        <version>7.1.23</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -1594,11 +1594,14 @@ function epSavePlaylist(showToast) {
         data: qs,
         async: true,
         success: function() {
+            epSetSaving(false);
             if (showToast) {
                 closeEditPlaylistModal();
                 brcToast('Playlist updated');
-            } else {
-                epSetSaving(false);
+                // BCON-174: refresh the playlist list so the updated name shows
+                // immediately — previously it only changed after a hard reload,
+                // making it look like the save hadn't taken.
+                Load(getAllPlaylistsURL());
             }
         },
         error: function() {

--- a/current/ui.config/pom.xml
+++ b/current/ui.config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.22</version>
+        <version>7.1.23</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.content/pom.xml
+++ b/current/ui.content/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.22</version>
+        <version>7.1.23</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.tests/pom.xml
+++ b/current/ui.tests/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.22</version>
+        <version>7.1.23</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
## Summary
Addresses Kevin's QA reopen on **BCON-174**: after editing a playlist name and saving, the new name only appeared after a hard page reload, so it looked like the save failed.

`epSavePlaylist` closed the modal + toasted on success but never re-rendered the list. Now it reloads the list on save success (the same `Load(getAllPlaylistsURL())` pattern used after a playlist delete).

## Verification
Built + deployed to local AEM; Playwright (update call mocked to avoid mutating the account) confirms a `search_playlists` reload fires immediately after Update, so the renamed playlist refreshes in place. Version → 7.1.23.

## Related QA reopens (no code change here — already resolved)
- **BCON-175 / BCON-184** (visual): fixed in #111 (7.1.21). Kevin's QA comments predated that merge (he was on the frozen 7.1.19 build).
- **BCON-186** (text-track loading/refresh): loading state + in-place re-fetch already shipped (#107-era, on 7.1.x); also a frozen-build artifact.
- **BCON-182** (label 409): root cause was the account not being label-enabled; resolved by enabling the `skip_vidmark` SETI flag.