### PR TITLE
fix: QA batch (BCON-188/189/191/192/193)

### DIFF
--- a/current/all/pom.xml
+++ b/current/all/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.23</version>
+        <version>7.1.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/analyse/pom.xml
+++ b/current/analyse/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.23</version>
+        <version>7.1.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/core/pom.xml
+++ b/current/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.23</version>
+        <version>7.1.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>brightcove.core</artifactId>

--- a/current/core/src/main/java/com/coresecure/brightcove/wrapper/sling/ServiceUtil.java
+++ b/current/core/src/main/java/com/coresecure/brightcove/wrapper/sling/ServiceUtil.java
@@ -1093,7 +1093,7 @@ public class ServiceUtil {
         ObjectNode master = JsonNodeFactory.instance.objectNode();
         ValueMap original_map = original_rendition.getProperties();
         Date orig_lastmod_time = original_map.get(JcrConstants.JCR_LASTMODIFIED,new Date(0));
-        LOGGER.trace("ORGINAL RENDITION : [Rendition Last Mod: {}] VS [Last Sync: {} ]"  ,orig_lastmod_time, brc_lastsync_time);
+        LOGGER.trace("ORIGINAL RENDITION : [Rendition Last Mod: {}] VS [Last Sync: {} ]"  ,orig_lastmod_time, brc_lastsync_time);
         ConfigurationGrabber cg = ServiceUtil.getConfigurationGrabber();
         ConfigurationService brcService = cg.getConfigurationService(account_id);
         String ingest_profile = brcService.getIngestProfile();
@@ -1215,7 +1215,7 @@ public class ServiceUtil {
         ObjectNode master = JsonNodeFactory.instance.objectNode();
 
         if (currentVideo.id == null) return false;
-        //ORGINAL RENDITION - REPLACE CHECK -  RENDITION PROCESS
+        //ORIGINAL RENDITION - REPLACE CHECK -  RENDITION PROCESS
         if (original_rendition != null)
         {
             master = setOriginalRendition(original_rendition, brc_lastsync_time, _asset, serviceUtil, currentVideo);

--- a/current/it.tests/pom.xml
+++ b/current/it.tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.23</version>
+        <version>7.1.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/pom.xml
+++ b/current/pom.xml
@@ -21,7 +21,7 @@
     <groupId>com.coresecure</groupId>
     <artifactId>brightcove</artifactId>
     <packaging>pom</packaging>
-    <version>7.1.23</version>
+    <version>7.1.24</version>
     <description>Brightcove Connector</description>
 
     <modules>

--- a/current/ui.apps.structure/pom.xml
+++ b/current/ui.apps.structure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.23</version>
+        <version>7.1.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.apps/pom.xml
+++ b/current/ui.apps/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.23</version>
+        <version>7.1.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -140,6 +140,14 @@ betty-titlebar {
   flex-shrink: 0;
 }
 
+/* BCON-192: while a sync is in flight, spin the sync icon so it reads as a
+   loading indicator (matches the design's animated symbol + the app's other
+   spinners, e.g. .brc-spinner). Was a static, dimmed icon. */
+#syncdbutton.brc-sync-btn.is-loading .brc-sync-icon {
+  animation: brc-spin 0.8s linear infinite;
+  transform-origin: 50% 50%;
+}
+
 .brc-account-trigger {
   display: flex;
   align-items: center;
@@ -584,6 +592,11 @@ betty-titlebar {
 #searchBut.brc-pill-search-go,
 #searchBut_pl.brc-pill-search-go {
   height: 28px;
+  /* BCON-189: center the label via flex (the off-centre nudge that caused the
+     misalignment lived in #searchDiv #searchBut — zeroed below). */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   margin: 0 0 0 6px;
   padding: 0 12px;
   background: #1a1a18;
@@ -601,7 +614,6 @@ betty-titlebar {
   cursor: pointer;
   box-shadow: none;
   filter: none;
-  line-height: 28px;
 }
 
 #searchBut.brc-pill-search-go:hover,
@@ -1078,13 +1090,16 @@ div.delConfPop {
   margin-top: 4px;
 }
 
+/* BCON-189: these legacy nudges pushed the Search button off the pill's
+   vertical centre (videos -2px, playlists +3px). With flex centering on the
+   pill the button centres on its own, so zero the offsets. */
 #searchDiv #searchBut {
-  top: -2px;
+  top: 0;
   position: relative;
 }
 
 #searchDiv_pl #searchBut {
-  top: 3px;
+  top: 0;
   position: relative;
 }
 

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -39,14 +39,11 @@ $( document ).ready(function() {
         CQ.Ext.util.Cookies.set('brc_act', $("#selAccount").val());
     }
 
-    // If we just reloaded after switching accounts, surface a toast.
+    // BCON-193: the post-switch confirmation toast was removed per QA. Clear any
+    // stale flag a prior build may have left behind, but show nothing.
     try {
-        var switchedAlias = window.sessionStorage && sessionStorage.getItem('brc_account_switched');
-        if (switchedAlias) {
-            sessionStorage.removeItem('brc_account_switched');
-            brcToast('Switched to ' + switchedAlias);
-        }
-    } catch (e) { /* sessionStorage unavailable — toast skipped */ }
+        if (window.sessionStorage) sessionStorage.removeItem('brc_account_switched');
+    } catch (e) { /* sessionStorage unavailable */ }
 });
 
 function showTableSpinner() {
@@ -290,11 +287,7 @@ $(function () {
                 } else {
                     document.cookie = 'brc_act=' + encodeURIComponent(accountId) + '; path=/';
                 }
-                try {
-                    if (window.sessionStorage) {
-                        sessionStorage.setItem('brc_account_switched', accountAlias);
-                    }
-                } catch (e) { /* sessionStorage unavailable — toast won't appear, switch still happens */ }
+                // BCON-193: no post-switch confirmation toast (removed per QA).
                 window.location.reload();
             },
             null /* Cancel just closes the dialog; no switch */);
@@ -3161,8 +3154,9 @@ function doPageList(total, type) {
 	        for (var i = 0; i < numOpt; i++) {
 	            options += '<option style="width:100%" id="' + i + '">';
 	            if (paging.generic == i) {
-	                num = (numOpt - 1 == i) ? (total - i * paging.size) : paging.size;
-	                document.getElementById('divVideoCount').innerHTML = num;
+	                // BCON-191: the count pill shows the TOTAL number of videos in
+	                // the account, not just how many are on the current page.
+	                document.getElementById('divVideoCount').innerHTML = total;
 	            }
 	            if (numOpt - 1 == i) {
 	                options += 'Page ' + (i+1) + ' (' + type + ' ' + (i * paging.size + 1) + ' to ' + total + ' )</option>';

--- a/current/ui.config/pom.xml
+++ b/current/ui.config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.23</version>
+        <version>7.1.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.content/pom.xml
+++ b/current/ui.content/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.23</version>
+        <version>7.1.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.tests/pom.xml
+++ b/current/ui.tests/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.23</version>
+        <version>7.1.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Resolves five of Kevin's newly-filed QA tickets (each built + verified on local AEM):

- **BCON-188** — typo `ORGINAL`→`ORIGINAL` in ServiceUtil (log + comment).
- **BCON-189** (visual) — Search button sat 2px above the pill's vertical centre, caused by a legacy `#searchDiv #searchBut { top:-2px }` nudge (and `+3px` on the playlist sibling). Zeroed both; button now centres via flex. Verified: button centre 163 == pill centre 163.
- **BCON-191** (High) — On accounts with >1 page, the count showed the current page's video count. `doPageList` now renders `o.totals`. Verified: shows 52 (account total), not 30.
- **BCON-192** (visual) — Sync Database button icon now spins (`brc-spin`) while syncing instead of a static dimmed icon.
- **BCON-193** — Removed the post-switch "Switched to <account>" confirmation toast (and its sessionStorage flag) per QA. *(Note: this reverses the toast added for BCON-178.)*

Version → **7.1.24**.

**Not included — BCON-190** (sort by ID across pages): the CMS API rejects `sort=id` (that's why id-sort is client-side per BCON-183), so true cross-page ID sort isn't possible server-side. Needs a product decision — see my note to Laurence.