### PR TITLE
fix(BCON-182/192): label apply-without-refresh + two-arrow sync icon

### DIFF
--- a/current/all/pom.xml
+++ b/current/all/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.25</version>
+        <version>7.1.26</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/analyse/pom.xml
+++ b/current/analyse/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.25</version>
+        <version>7.1.26</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/core/pom.xml
+++ b/current/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.25</version>
+        <version>7.1.26</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>brightcove.core</artifactId>

--- a/current/it.tests/pom.xml
+++ b/current/it.tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.25</version>
+        <version>7.1.26</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/pom.xml
+++ b/current/pom.xml
@@ -21,7 +21,7 @@
     <groupId>com.coresecure</groupId>
     <artifactId>brightcove</artifactId>
     <packaging>pom</packaging>
-    <version>7.1.25</version>
+    <version>7.1.26</version>
     <description>Brightcove Connector</description>
 
     <modules>

--- a/current/ui.apps.structure/pom.xml
+++ b/current/ui.apps.structure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.25</version>
+        <version>7.1.26</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.apps/pom.xml
+++ b/current/ui.apps/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.25</version>
+        <version>7.1.26</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/js/brcUI.js
@@ -1284,12 +1284,14 @@ function loadLabels() {
                         return; // keep the dialog open
                     }
 
-                    // Brightcove labels are hierarchical paths and must start
-                    // with '/'. Be forgiving and prepend it when the user omits
-                    // it, rather than rejecting an otherwise-valid name.
-                    if (labelName.charAt(0) !== '/') {
-                        labelName = '/' + labelName;
-                    }
+                    // Brightcove labels are hierarchical paths that must be both
+                    // '/'-prefixed AND '/'-suffixed (e.g. /news/). Normalize fully
+                    // here so (a) we create the canonical path the API stores and
+                    // (b) the optimistic dropdown option below matches the path the
+                    // apply-to-video step computes via normalizeLabelPath — without
+                    // this, a freshly-created label couldn't be applied until a hard
+                    // refresh re-fetched it in canonical form (BCON-182).
+                    labelName = normalizeLabelPath(labelName);
 
                     $input.removeClass('error');
                     $err.hide();

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
@@ -33,8 +33,9 @@
                     <h1 class="brc-title">Brightcove Admin</h1>
                     <div class="brc-header-actions">
                         <button type="button" id="syncdbutton" class="brc-sync-btn" alt="Brightcove Dataload" onClick="syncDB()">
-                            <svg class="brc-sync-icon" width="13" height="13" viewBox="0 0 16 16" aria-hidden="true">
-                                <path d="M14 8a6 6 0 1 1-1.757-4.243M14 2v4h-4" stroke="currentColor" stroke-width="1.6" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+                            <!-- BCON-192: two-arrow sync icon to match Figma (was a single-arc refresh arrow). -->
+                            <svg class="brc-sync-icon" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                                <path d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46A7.93 7.93 0 0 0 20 12c0-4.42-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74A7.93 7.93 0 0 0 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4v3z"/>
                             </svg>
                             <span class="brc-sync-btn-label">Sync database</span>
                         </button>

--- a/current/ui.config/pom.xml
+++ b/current/ui.config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.25</version>
+        <version>7.1.26</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.content/pom.xml
+++ b/current/ui.content/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.25</version>
+        <version>7.1.26</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.tests/pom.xml
+++ b/current/ui.tests/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.25</version>
+        <version>7.1.26</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Two QA reopens (both verified on local AEM):

**BCON-182** — Creating a label then applying it to a video failed ("label not found") unless you hard-refreshed. Root cause: the create dialog only `/`-prefixed the name (`/foo`), but the apply step (`#labelInput`) compares `normalizeLabelPath(raw)` = `/foo/`, so the optimistically-added dropdown option (`/foo`) never matched the apply path until a reload re-fetched the canonical `/foo/`. Now the name is fully normalized on create, so create + dropdown option + apply all agree. Verified: a freshly-created label applies immediately (no refresh).

**BCON-192** — Replaced the single-arc refresh glyph on the Sync Database button with a two-arrow sync icon to match the Figma Kevin attached. Verified by screenshot.

Version → 7.1.26.