### PR TITLE
fix(BCON-175 reopen + BCON-195): variants right-align, panel scrollbar, single sync indicator

### DIFF
--- a/current/all/pom.xml
+++ b/current/all/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.27</version>
+        <version>7.1.28</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/analyse/pom.xml
+++ b/current/analyse/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.27</version>
+        <version>7.1.28</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/core/pom.xml
+++ b/current/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.27</version>
+        <version>7.1.28</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>brightcove.core</artifactId>

--- a/current/it.tests/pom.xml
+++ b/current/it.tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.27</version>
+        <version>7.1.28</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/pom.xml
+++ b/current/pom.xml
@@ -21,7 +21,7 @@
     <groupId>com.coresecure</groupId>
     <artifactId>brightcove</artifactId>
     <packaging>pom</packaging>
-    <version>7.1.27</version>
+    <version>7.1.28</version>
     <description>Brightcove Connector</description>
 
     <modules>

--- a/current/ui.apps.structure/pom.xml
+++ b/current/ui.apps.structure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.27</version>
+        <version>7.1.28</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.apps/pom.xml
+++ b/current/ui.apps/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.27</version>
+        <version>7.1.28</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -2811,6 +2811,17 @@ body.brc-mtf-open {
      the left divider); the sections inside carry their own borders. */
   border-left: 1px solid #e8e6df;
   background: #fff;
+  /* BCON-175 (reopen): the panel scrolls internally (max-height:100vh) so the
+     bottom of a tall panel stays reachable, but on always-show-scrollbar
+     setups that scrollbar reads as a stray vertical "bar" on the panel's right
+     edge. Hide it visually while keeping the panel scrollable. */
+  scrollbar-width: none;        /* Firefox */
+  -ms-overflow-style: none;     /* old Edge/IE */
+}
+
+.brc-panel-inner::-webkit-scrollbar {  /* Chrome / Safari */
+  width: 0;
+  height: 0;
 }
 
 .brc-panel-header {
@@ -3090,6 +3101,10 @@ body.brc-mtf-open {
 /* Variants in panel */
 .brc-variant-link {
   display: block;
+  /* BCON-175: full width so text-align:right pushes the value to the cell's
+     right edge (a content-width block button stays left, ignoring the align). */
+  width: 100%;
+  box-sizing: border-box;
   background: none;
   border: none;
   padding: 0;
@@ -3097,7 +3112,9 @@ body.brc-mtf-open {
   color: #1a1a18;
   text-decoration: none;
   cursor: pointer;
-  text-align: left;
+  /* BCON-175: variant values right-justify like every other Video Info value
+     (the block link was forcing them left). */
+  text-align: right;
   font-family: inherit;
   line-height: 1.6;
 }

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/brightcoveadmin.html
@@ -729,9 +729,7 @@
                     </div>
                     <div id="syncOverlayTitle" class="brc-sync-title">Syncing database</div>
                     <div class="brc-sync-subtitle">Fetching latest videos and playlists&hellip;</div>
-                    <div class="brc-sync-progress-track" role="progressbar" aria-label="Sync progress" aria-valuetext="Indeterminate">
-                        <div class="brc-sync-progress-fill"></div>
-                    </div>
+                    <!-- BCON-195: removed the indeterminate progress bar — the spinner wheel above is the single loading indicator. -->
                 </div>
             </div>
         <!-- Variant Details modal (BCON-143) -->

--- a/current/ui.config/pom.xml
+++ b/current/ui.config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.27</version>
+        <version>7.1.28</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.content/pom.xml
+++ b/current/ui.content/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.27</version>
+        <version>7.1.28</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.tests/pom.xml
+++ b/current/ui.tests/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.27</version>
+        <version>7.1.28</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
**BCON-175** (reopened 06-11) — two items from Kevin's latest comment:
- *Variants not right-justified.* `.brc-variant-link` is a `display:block` button rendering at content width, so `text-align:right` had nothing to align against. Set `width:100%` → variants now flush-right like every other Video Info value. Verified by screenshot.
- *Still a bar to the right of the panel.* It's `.brc-panel-inner`'s scrollbar (`max-height:100vh; overflow-y:auto`), which is invisible with overlay scrollbars (why earlier checks looked clean) but a persistent grey bar on always-show-scrollbar setups like Kevin's. Hid it (`scrollbar-width:none` + `::-webkit-scrollbar{width:0}`) while keeping the panel scrollable so a tall panel's Save button stays reachable.

**BCON-195** — the Sync Database overlay showed a spinner wheel AND an indeterminate progress bar; removed the progress bar so the wheel is the single loading indicator. Verified: overlay renders wheel only.

Version → 7.1.28.