### PR TITLE
fix: video details panel stretches to the screen's right edge

### DIFF
--- a/current/all/pom.xml
+++ b/current/all/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.28</version>
+        <version>7.1.29</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/analyse/pom.xml
+++ b/current/analyse/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.28</version>
+        <version>7.1.29</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/core/pom.xml
+++ b/current/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.28</version>
+        <version>7.1.29</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>brightcove.core</artifactId>

--- a/current/it.tests/pom.xml
+++ b/current/it.tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.28</version>
+        <version>7.1.29</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/pom.xml
+++ b/current/pom.xml
@@ -21,7 +21,7 @@
     <groupId>com.coresecure</groupId>
     <artifactId>brightcove</artifactId>
     <packaging>pom</packaging>
-    <version>7.1.28</version>
+    <version>7.1.29</version>
     <description>Brightcove Connector</description>
 
     <modules>

--- a/current/ui.apps.structure/pom.xml
+++ b/current/ui.apps.structure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.28</version>
+        <version>7.1.29</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.apps/pom.xml
+++ b/current/ui.apps/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.28</version>
+        <version>7.1.29</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-tools/css/style.css
@@ -1153,7 +1153,16 @@ div.hLine {
 }
 
 #divConsole {
-  padding: 0 20px 20px;
+  /* No right gutter — the video details panel (last cell) stretches to the
+     screen's right edge. Left/bottom padding kept for the list. */
+  padding: 0 0 20px 20px;
+}
+
+/* BCON: the video details panel fills its cell to the right edge so the grey
+   header and sections aren't cut off short of the screen edge (the shared
+   td.tdMetadata rule adds a 20px right gutter meant for the list header). */
+#tdMeta.tdMetadata {
+  padding-right: 0;
 }
 
 .foundation-layout-panel-content {

--- a/current/ui.config/pom.xml
+++ b/current/ui.config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.28</version>
+        <version>7.1.29</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.content/pom.xml
+++ b/current/ui.content/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.28</version>
+        <version>7.1.29</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.tests/pom.xml
+++ b/current/ui.tests/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.1.28</version>
+        <version>7.1.29</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
QA feedback: the grey title bar in the video details panel was cut off short of the screen's right edge, with dead space beside it.

Cause: two stacked right gutters — the shared `td.tdMetadata` rule's `padding: 0 20px` and `#divConsole`'s 20px right padding. Removed both on the panel side only (`#tdMeta { padding-right: 0 }` + `#divConsole { padding-right: 0 }`); the list keeps its left margin.

Verified on local AEM: `#tdMeta`, `.brc-panel-inner`, and `.brc-panel-header` all now reach the viewport's right edge (1440/1440). Version → 7.1.29.