### PR TITLE
fix(BGS-1690): forward-port edit-listener refresh fix to cloud-master

### DIFF
--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-base/players/html5-player/js/BrightcoveExperiences.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-base/players/html5-player/js/BrightcoveExperiences.js
@@ -123,6 +123,13 @@ function createPlayers(root) {
     var pendingRoots = [];
     var scheduled = false;
 
+    // Bind to window so the native methods retain their receiver — calling
+    // a detached window.requestAnimationFrame throws TypeError: Illegal
+    // invocation in strict mode, and even in non-strict mode it's fragile.
+    var defer = typeof window.requestAnimationFrame === "function"
+        ? window.requestAnimationFrame.bind(window)
+        : function (cb) { return window.setTimeout(cb, 0); };
+
     function flush() {
         scheduled = false;
         var roots = pendingRoots;
@@ -136,7 +143,7 @@ function createPlayers(root) {
         pendingRoots.push(root);
         if (!scheduled) {
             scheduled = true;
-            (window.requestAnimationFrame || setTimeout)(flush, 0);
+            defer(flush);
         }
     }
 

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-base/players/html5-player/js/BrightcoveExperiences.js
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/clientlibs/clientlib-base/players/html5-player/js/BrightcoveExperiences.js
@@ -34,8 +34,9 @@
 document.addEventListener("DOMContentLoaded", (event) => {
   createPlayers();
 });
-function createPlayers() {
-    var all = document.getElementsByClassName("brightcove-container");
+function createPlayers(root) {
+    var scope = root || document;
+    var all = scope.getElementsByClassName("brightcove-container");
     for (var i = 0, max = all.length; i < max; i++) {
         var selected_element = all[i];
         var playerID= selected_element.getAttribute("data-playerid");
@@ -109,3 +110,60 @@ function createPlayers() {
         document.body.appendChild(s);
     }
 }
+
+// BGS-1690: In AEM authoring, REFRESH_SELF swaps in new component HTML but
+// DOMContentLoaded never re-fires, so createPlayers() doesn't bootstrap the
+// new container and the live preview stays blank until manual refresh.
+// Watch the document for inserted/replaced .brightcove-container nodes and
+// re-init just the affected subtree. Works for insert / edit / copy / paste
+// regardless of which AEM editor event fires.
+(function () {
+    if (typeof MutationObserver === "undefined") return;
+
+    var pendingRoots = [];
+    var scheduled = false;
+
+    function flush() {
+        scheduled = false;
+        var roots = pendingRoots;
+        pendingRoots = [];
+        for (var i = 0; i < roots.length; i++) {
+            createPlayers(roots[i]);
+        }
+    }
+
+    function schedule(root) {
+        pendingRoots.push(root);
+        if (!scheduled) {
+            scheduled = true;
+            (window.requestAnimationFrame || setTimeout)(flush, 0);
+        }
+    }
+
+    var observer = new MutationObserver(function (mutations) {
+        for (var i = 0; i < mutations.length; i++) {
+            var added = mutations[i].addedNodes;
+            for (var j = 0; j < added.length; j++) {
+                var node = added[j];
+                if (node.nodeType !== 1) continue;
+                if (node.classList && node.classList.contains("brightcove-container")) {
+                    schedule(node.parentNode || node);
+                } else if (node.querySelector && node.querySelector(".brightcove-container")) {
+                    schedule(node);
+                }
+            }
+        }
+    });
+
+    function start() {
+        if (document.body) {
+            observer.observe(document.body, { childList: true, subtree: true });
+        }
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", start);
+    } else {
+        start();
+    }
+})();

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/content/brightcoveexperiences/_cq_editConfig.xml
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/content/brightcoveexperiences/_cq_editConfig.xml
@@ -6,8 +6,8 @@
     jcr:primaryType="cq:EditConfig">
     <cq:listeners
         jcr:primaryType="cq:EditListenersConfig"
-        aftercopy="REFRESH_PAGE"
-        afterdelete="REFRESH_PAGE"
-        afteredit="REFRESH_PAGE"
-        afterinsert="REFRESH_PAGE"/>
+        aftercopy="REFRESH_SELF"
+        afterdelete="REFRESH_SELF"
+        afteredit="REFRESH_SELF"
+        afterinsert="REFRESH_SELF"/>
 </jcr:root>

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/content/brightcoveplayer-playlist/_cq_editConfig.xml
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/content/brightcoveplayer-playlist/_cq_editConfig.xml
@@ -18,8 +18,8 @@
     </cq:dropTargets>
     <cq:listeners
         jcr:primaryType="cq:EditListenersConfig"
-        aftercopy="REFRESH_PAGE"
-        afterdelete="REFRESH_PAGE"
-        afteredit="REFRESH_PAGE"
-        afterinsert="REFRESH_PAGE"/>
+        aftercopy="REFRESH_SELF"
+        afterdelete="REFRESH_SELF"
+        afteredit="REFRESH_SELF"
+        afterinsert="REFRESH_SELF"/>
 </jcr:root>

--- a/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/content/brightcoveplayer/_cq_editConfig.xml
+++ b/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/content/brightcoveplayer/_cq_editConfig.xml
@@ -13,8 +13,8 @@
     </cq:dropTargets>
     <cq:listeners
         jcr:primaryType="cq:EditListenersConfig"
-        aftercopy="REFRESH_PAGE"
-        afterdelete="REFRESH_PAGE"
-        afteredit="REFRESH_PAGE"
-        afterinsert="REFRESH_PAGE"/>
+        aftercopy="REFRESH_SELF"
+        afterdelete="REFRESH_SELF"
+        afteredit="REFRESH_SELF"
+        afterinsert="REFRESH_SELF"/>
 </jcr:root>


### PR DESCRIPTION
## Summary

Forward-ports the BGS-1690 fix onto `cloud-master`. The fix shipped in `7.1.4-cloud` on the `release/7.1.4-cloud` hotfix line but was never merged back to mainline, so it regressed: `7.2.0-cloud` (cut from `cloud-master`) does not contain it, and the reported authoring bug is back in the current release.

## The bug

When an author adds or edits the Brightcove component in AEM authoring, the entire authoring page performs a full refresh (`REFRESH_PAGE`), so authors lose scroll position and dialog state on every interaction.

## The fix

1. **`_cq_editConfig.xml` (all three components: `brightcoveplayer`, `brightcoveplayer-playlist`, `brightcoveexperiences`)** flips `cq:listeners` from `REFRESH_PAGE` to `REFRESH_SELF` for all four events (`aftercopy`, `afterdelete`, `afteredit`, `afterinsert`). `afterdelete` is kept explicitly because AEM's omitted-listener default is `REFRESH_PAGE`.
2. **`BrightcoveExperiences.js`**: `REFRESH_SELF` swaps in new component HTML via XHR without re-firing `DOMContentLoaded`, so the live preview would go blank until a manual refresh. A `MutationObserver` re-runs `createPlayers()` scoped to the inserted/replaced `.brightcove-container` subtree. Includes the follow-up that binds `requestAnimationFrame` to `window` (flagged by Cursor Bugbot on the original PR) so the deferred scheduler does not throw `Illegal invocation` under strict mode.

## Provenance

These are the same two commits released in `7.1.4-cloud`, cherry-picked cleanly onto current `cloud-master` (the four target files were untouched by intervening work). Commit messages reworded to strip a customer identifier present in the original message.

## Verification

- `node --check` on the modified clientlib passes.
- All three `_cq_editConfig.xml` files confirmed at `REFRESH_SELF` for all four events.
