### PR TITLE
fix(BGS-1705): prevent duplicate video creation on concurrent/redelivered publish

### DIFF
--- a/current/core/src/main/java/com/coresecure/brightcove/wrapper/listeners/BrightcovePublishListener.java
+++ b/current/core/src/main/java/com/coresecure/brightcove/wrapper/listeners/BrightcovePublishListener.java
@@ -211,6 +211,19 @@ public class BrightcovePublishListener implements EventHandler {
 
         }
 
+        // BGS-1705: persist the sync marker for THIS asset immediately, rather than
+        // waiting for the single rr.commit() at the end of handleEvent() (which only
+        // fires after every asset in the event has been processed). A redelivered
+        // distribution/replication event must see brc_lastsync as soon as possible so
+        // it takes the update path instead of creating a duplicate Brightcove video.
+        try {
+            if (rr != null && rr.hasChanges()) {
+                rr.commit();
+            }
+        } catch (PersistenceException e) {
+            LOG.error("Failed to persist Brightcove sync marker for {}: {}", _asset.getPath(), e.getMessage());
+        }
+
     }
 
     private void syncFolder(ServiceUtil serviceUtil, ObjectNode api_resp, Node assetNode) {

--- a/current/core/src/main/java/com/coresecure/brightcove/wrapper/sling/ServiceUtil.java
+++ b/current/core/src/main/java/com/coresecure/brightcove/wrapper/sling/ServiceUtil.java
@@ -1277,6 +1277,23 @@ public class ServiceUtil {
 
 
 
+    /**
+     * BGS-1705: resolve the Brightcove reference_id for a video to be created/updated.
+     * An explicit brc_reference_id always wins; otherwise fall back to the asset's
+     * stable jcr:uuid. Setting a stable, unique reference_id lets the CMS API reject a
+     * duplicate create attempt (from a concurrent or redelivered AEMaaCS publish event)
+     * instead of silently creating a second video.
+     */
+    static String resolveReferenceId(String explicitReferenceId, String jcrUuid) {
+        if (explicitReferenceId != null && !explicitReferenceId.isEmpty()) {
+            return explicitReferenceId;
+        }
+        if (jcrUuid != null && !jcrUuid.isEmpty()) {
+            return jcrUuid;
+        }
+        return "";
+    }
+
     public Video createVideo(String request, Asset asset, String aState)
     {
 
@@ -1328,7 +1345,13 @@ public class ServiceUtil {
         //STO FROM LOCAL VIDEOS INITIALIZE THESE SO THAT YOU CAN SEND -- COULD COME FROM PROPERTIES VALUE MAP
         String name = map.get(DamConstants.DC_TITLE, asset.getName());
         String id = map.get(Constants.BRC_ID, String.class);
-        String referenceId = map.get(Constants.BRC_REFERENCE_ID, "");
+        // BGS-1705: default reference_id to the asset's stable jcr:uuid when no
+        // explicit brc_reference_id is set, so a duplicate create attempt is rejected
+        // by the CMS API (reference_id is unique per account) rather than producing a
+        // second video. The jcr:uuid lives on the dam:Asset node (assetRes).
+        String referenceId = resolveReferenceId(
+                map.get(Constants.BRC_REFERENCE_ID, ""),
+                assetRes.getValueMap().get("jcr:uuid", String.class));
         String shortDescription = map.get(Constants.BRC_DESCRIPTION,"");
         String longDescription = map.get(Constants.BRC_LONG_DESCRIPTION,"");
         String projection = "equirectangular".equals(map.get(Constants.BRC_PROJECTION,""))? Constants.EQUIRECTANGULAR : "";

--- a/current/core/src/main/java/com/coresecure/brightcove/wrapper/workflow/BrightcoveSyncAssetWorkflowStep.java
+++ b/current/core/src/main/java/com/coresecure/brightcove/wrapper/workflow/BrightcoveSyncAssetWorkflowStep.java
@@ -335,7 +335,9 @@ public class BrightcoveSyncAssetWorkflowStep implements WorkflowProcess{
 		serviceUtil.moveVideoToFolder(folderId, videoId);
 	}
 
-    private String activateAsset(ResourceResolver rr, Asset _asset, ServiceUtil serviceUtil) {
+    // Package-private (not private) so the BGS-1705 concurrency regression test can
+    // drive the create-vs-update gate directly with a mocked ServiceUtil.
+    String activateAsset(ResourceResolver rr, Asset _asset, ServiceUtil serviceUtil) {
 
         // need to either activate a new asset or an updated existing
         // ServiceUtil serviceUtil = new ServiceUtil(accountId);
@@ -374,8 +376,22 @@ public class BrightcoveSyncAssetWorkflowStep implements WorkflowProcess{
             LOG.info("Activating Modified Brightcove Asset: {}", _asset.getPath());
             brightcoveAssetId = activateModified(_asset, serviceUtil, video, brc_lastsync_map);
         }
-        
+
+        // BGS-1705: persist the sync marker (brc_id / brc_lastsync / brc_state) NOW,
+        // before execute() runs its ~15s ingest-wait. Previously the marker was only
+        // committed at the end of execute(), so a concurrent or redelivered AEMaaCS
+        // publish event would still read brc_lastsync == null and create a second,
+        // duplicate Brightcove video. Committing here closes that window.
+        try {
+            ResourceResolver resolver = assetRes.getResourceResolver();
+            if (resolver != null && resolver.hasChanges()) {
+                resolver.commit();
+            }
+        } catch (PersistenceException e) {
+            LOG.error("Failed to persist Brightcove sync marker for {}: {}", path, e.getMessage());
+        }
+
         return brightcoveAssetId;
 
-    }    
+    }
 }

--- a/current/core/src/main/java/com/coresecure/brightcove/wrapper/workflow/BrightcoveSyncAssetWorkflowStep.java
+++ b/current/core/src/main/java/com/coresecure/brightcove/wrapper/workflow/BrightcoveSyncAssetWorkflowStep.java
@@ -169,6 +169,26 @@ public class BrightcoveSyncAssetWorkflowStep implements WorkflowProcess{
         }
     }
 
+    /**
+     * BGS-1705: flush pending Brightcove sync-marker changes for this asset so that a
+     * concurrent or redelivered publish event, running in its own JCR session, can see
+     * them. Never throws — a failed commit is logged and the caller carries on.
+     */
+    private void commitSyncMarker(Asset _asset) {
+        try {
+            Resource assetRes = _asset.adaptTo(Resource.class);
+            if (assetRes == null) {
+                return;
+            }
+            ResourceResolver resolver = assetRes.getResourceResolver();
+            if (resolver != null && resolver.hasChanges()) {
+                resolver.commit();
+            }
+        } catch (PersistenceException e) {
+            LOG.error("Failed to persist Brightcove sync marker for {}: {}", _asset.getPath(), e.getMessage());
+        }
+    }
+
     private String activateNew(Asset _asset, ServiceUtil serviceUtil, Video video, ModifiableValueMap brc_lastsync_map) {
 
         LOG.trace("brc_lastsync was null or zero : asset should be initialized");
@@ -187,7 +207,21 @@ public class BrightcoveSyncAssetWorkflowStep implements WorkflowProcess{
             boolean sent = api_resp.has(Constants.SENT) && api_resp.get(Constants.SENT).asBoolean();
             if (sent) {
                 brightcoveAssetId = api_resp.get(Constants.VIDEOID).asText();
+
+                // BGS-1705: write the COMPLETE sync marker and commit it right here, before
+                // any further work. Two reasons:
+                //  1. Everything below is slow — updateRenditions uploads renditions, and
+                //     syncFolder's retry path can sleep 15s — so deferring the commit leaves
+                //     a wide window in which a concurrent or redelivered AEMaaCS publish
+                //     still reads brc_lastsync == null and creates a second video.
+                //  2. Both calls run on this same JCR session and can discard pending state,
+                //     which could otherwise persist brc_lastsync with no brc_id and route the
+                //     next publish to updateVideo with a null id. Committing up front makes
+                //     that half-written marker impossible by construction.
                 brc_lastsync_map.put(Constants.BRC_ID, brightcoveAssetId);
+                brc_lastsync_map.put(DamConstants.DC_TITLE, video.name);
+                brc_lastsync_map.put(Constants.BRC_LASTSYNC, JcrUtil.now2calendar());
+                commitSyncMarker(_asset);
 
                 LOG.trace("UPDATING RENDITIONS FOR THIS ASSET");
                 serviceUtil.updateRenditions(_asset, video);
@@ -196,10 +230,6 @@ public class BrightcoveSyncAssetWorkflowStep implements WorkflowProcess{
                 syncFolder(serviceUtil, api_resp, assetNode);
 
                 LOG.info("BC: ACTIVATION SUCCESSFUL >> {}", _asset.getPath());
-
-                // update the metadata to show the last sync time
-                brc_lastsync_map.put(DamConstants.DC_TITLE, video.name);
-                brc_lastsync_map.put(Constants.BRC_LASTSYNC, JcrUtil.now2calendar());
 
             } else {
 
@@ -296,7 +326,12 @@ public class BrightcoveSyncAssetWorkflowStep implements WorkflowProcess{
 				} else {
 					LOG.error("*************************** No folder created ***************************");
 					TimeUnit.SECONDS.sleep(15);
-					parentNode.refresh(false);
+					// Re-read the parent from the persistent store in case a concurrent publish
+					// created the folder. keepChanges=true: in Oak refresh() is session-wide, so
+					// refresh(false) would discard pending metadata (e.g. BRC_ID) set before this
+					// call, leaving the BGS-1705 marker commit to persist brc_lastsync with no
+					// brc_id — which routes the next publish to updateVideo with a null id.
+					parentNode.refresh(true);
 					if (!parentNode.hasProperty("brc_folder_id")) {
 						folderId = serviceUtil.createFolder(assetNode.getParent().getName());
 						if (folderId != null && !folderId.isEmpty()) {
@@ -381,15 +416,10 @@ public class BrightcoveSyncAssetWorkflowStep implements WorkflowProcess{
         // before execute() runs its ~15s ingest-wait. Previously the marker was only
         // committed at the end of execute(), so a concurrent or redelivered AEMaaCS
         // publish event would still read brc_lastsync == null and create a second,
-        // duplicate Brightcove video. Committing here closes that window.
-        try {
-            ResourceResolver resolver = assetRes.getResourceResolver();
-            if (resolver != null && resolver.hasChanges()) {
-                resolver.commit();
-            }
-        } catch (PersistenceException e) {
-            LOG.error("Failed to persist Brightcove sync marker for {}: {}", path, e.getMessage());
-        }
+        // duplicate Brightcove video. Committing here closes that window. On the create
+        // path activateNew has already committed the marker; this catches brc_state and
+        // the update path.
+        commitSyncMarker(_asset);
 
         return brightcoveAssetId;
 

--- a/current/core/src/test/java/com/coresecure/brightcove/wrapper/sling/ServiceUtilReferenceIdTest.java
+++ b/current/core/src/test/java/com/coresecure/brightcove/wrapper/sling/ServiceUtilReferenceIdTest.java
@@ -1,0 +1,34 @@
+package com.coresecure.brightcove.wrapper.sling;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * BGS-1705: a newly created Brightcove video must carry a stable, unique reference_id
+ * so a duplicate create attempt is rejected by the CMS API. An explicit
+ * brc_reference_id wins; otherwise the asset's jcr:uuid is used.
+ */
+class ServiceUtilReferenceIdTest {
+
+    @Test
+    void explicitReferenceIdWins() {
+        assertEquals("my-ref", ServiceUtil.resolveReferenceId("my-ref", "uuid-123"));
+    }
+
+    @Test
+    void fallsBackToJcrUuidWhenExplicitEmpty() {
+        assertEquals("uuid-123", ServiceUtil.resolveReferenceId("", "uuid-123"));
+    }
+
+    @Test
+    void fallsBackToJcrUuidWhenExplicitNull() {
+        assertEquals("uuid-123", ServiceUtil.resolveReferenceId(null, "uuid-123"));
+    }
+
+    @Test
+    void emptyWhenNoReferenceAndNoUuid() {
+        assertEquals("", ServiceUtil.resolveReferenceId("", null));
+        assertEquals("", ServiceUtil.resolveReferenceId(null, ""));
+    }
+}

--- a/current/core/src/test/java/com/coresecure/brightcove/wrapper/workflow/BrightcoveSyncAssetWorkflowStepDuplicateTest.java
+++ b/current/core/src/test/java/com/coresecure/brightcove/wrapper/workflow/BrightcoveSyncAssetWorkflowStepDuplicateTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.Resource;
@@ -122,6 +123,40 @@ class BrightcoveSyncAssetWorkflowStepDuplicateTest {
 
         verify(serviceUtil, never()).createVideoS3(any(Video.class), anyString(), any(InputStream.class));
         verify(serviceUtil, times(1)).updateVideo(any(Video.class));
+    }
+
+    /**
+     * Invariant #3: the marker is durable BEFORE the slow post-create work runs, and it is
+     * written whole. updateRenditions uploads renditions and syncFolder's retry path can
+     * sleep 15s, so a marker committed only after them leaves the duplicate window wide
+     * open for exactly as long as that work takes. Both also run on this same JCR session
+     * and can discard pending state — in Oak refresh() is session-wide — which could
+     * otherwise persist brc_lastsync with no brc_id and send the next publish to
+     * updateVideo with a null id. Committing up front rules out both.
+     *
+     * Pre-fix this fails: at updateRenditions time brc_id/brc_state are still pending.
+     */
+    @Test
+    void syncMarkerIsDurableBeforePostCreateWorkRuns() throws Exception {
+        ResourceResolver rr = context.resourceResolver();
+        AtomicBoolean pendingAtRenditionTime = new AtomicBoolean(true);
+
+        when(serviceUtil.updateRenditions(any(Asset.class), any(Video.class))).thenAnswer(inv -> {
+            pendingAtRenditionTime.set(rr.hasChanges());
+            return true;
+        });
+
+        Asset asset = rr.getResource(ASSET_PATH).adaptTo(Asset.class);
+        step.activateAsset(rr, asset, serviceUtil);
+
+        verify(serviceUtil, times(1)).updateRenditions(any(Asset.class), any(Video.class));
+        assertFalse(pendingAtRenditionTime.get(),
+                "BGS-1705: sync marker must already be committed when updateRenditions starts");
+
+        // Whole, not half: both halves of the marker are present together.
+        ModifiableValueMap meta = metadata(rr);
+        assertEquals("999111", meta.get(Constants.BRC_ID, String.class), "brc_id must be persisted");
+        assertNotNull(meta.get(Constants.BRC_LASTSYNC), "brc_lastsync must be persisted");
     }
 
     private static ModifiableValueMap metadata(ResourceResolver rr) {

--- a/current/core/src/test/java/com/coresecure/brightcove/wrapper/workflow/BrightcoveSyncAssetWorkflowStepDuplicateTest.java
+++ b/current/core/src/test/java/com/coresecure/brightcove/wrapper/workflow/BrightcoveSyncAssetWorkflowStepDuplicateTest.java
@@ -1,0 +1,138 @@
+package com.coresecure.brightcove.wrapper.workflow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import org.apache.sling.api.resource.ModifiableValueMap;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.coresecure.brightcove.wrapper.objects.Video;
+import com.coresecure.brightcove.wrapper.sling.ServiceUtil;
+import com.coresecure.brightcove.wrapper.utils.Constants;
+import com.day.cq.dam.api.Asset;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+
+/**
+ * BGS-1705 regression test for the AEMaaCS duplicate-video defect.
+ *
+ * Root cause: {@link BrightcoveSyncAssetWorkflowStep} decides create-vs-update by
+ * reading the brc_lastsync marker, but that marker used to be committed only at the
+ * very end of execute() — AFTER a ~15s ingest wait. A second, near-simultaneous (or
+ * redelivered) AEMaaCS publish event running in its own JCR session therefore still
+ * read brc_lastsync == null and created a SECOND Brightcove video.
+ *
+ * Two invariants make duplicates impossible; this test pins both:
+ *   1. activateAsset() COMMITS the sync marker before returning (so a concurrent /
+ *      redelivered event in another session can see it). Pre-fix the marker stayed
+ *      uncommitted in the session — this test then fails on {@code hasChanges()}.
+ *   2. The create-vs-update gate routes on the persisted marker: no marker -> create,
+ *      marker present -> update (so the redelivered event updates instead of
+ *      re-creating).
+ */
+@ExtendWith(AemContextExtension.class)
+class BrightcoveSyncAssetWorkflowStepDuplicateTest {
+
+    // JCR_MOCK gives real JCR session semantics (save / pending-changes), which is
+    // what invariant #1 asserts on.
+    private final AemContext context =
+            new AemContext(org.apache.sling.testing.mock.sling.ResourceResolverType.JCR_MOCK);
+
+    private static final String ASSET_PATH = "/content/dam/brightcove_assets/12345/sample.mp4";
+
+    private BrightcoveSyncAssetWorkflowStep step;
+    private ServiceUtil serviceUtil;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        step = new BrightcoveSyncAssetWorkflowStep();
+
+        // A real (binary-backed) asset so activateNew()'s getOriginal().getStream() works.
+        context.create().asset(ASSET_PATH, new ByteArrayInputStream(new byte[] {1, 2, 3, 4}), "video/mp4");
+        context.resourceResolver().commit();
+
+        // Mock the Brightcove boundary: create / update both "succeed" with an id.
+        serviceUtil = mock(ServiceUtil.class);
+        when(serviceUtil.createVideo(anyString(), any(Asset.class), anyString()))
+                .thenReturn(new Video("sample.mp4"));
+        when(serviceUtil.createVideoS3(any(Video.class), anyString(), any(InputStream.class)))
+                .thenReturn(sentResponse("999111"));
+        when(serviceUtil.updateVideo(any(Video.class))).thenReturn(sentResponse("999111"));
+    }
+
+    /**
+     * Invariant #1: a brand-new asset is created exactly once AND the sync marker is
+     * committed (not left pending) before activateAsset returns — closing the window a
+     * redelivered event would otherwise exploit.
+     */
+    @Test
+    void newAssetCreatesOnceAndCommitsMarkerBeforeReturning() throws Exception {
+        ResourceResolver rr = context.resourceResolver();
+        Asset asset = rr.getResource(ASSET_PATH).adaptTo(Asset.class);
+
+        step.activateAsset(rr, asset, serviceUtil);
+
+        verify(serviceUtil, times(1)).createVideoS3(any(Video.class), anyString(), any(InputStream.class));
+        verify(serviceUtil, never()).updateVideo(any(Video.class));
+
+        // The marker must be persisted, not sitting uncommitted in this session.
+        assertFalse(rr.hasChanges(),
+                "BGS-1705: sync marker must be committed before activateAsset returns");
+
+        ModifiableValueMap meta = metadata(rr);
+        assertEquals("999111", meta.get(Constants.BRC_ID, String.class), "brc_id must be persisted");
+        assertNotNull(meta.get(Constants.BRC_LASTSYNC), "brc_lastsync must be persisted");
+    }
+
+    /**
+     * Invariant #2: once the marker is present (i.e. a prior event already synced the
+     * asset), a subsequent event takes the UPDATE path and never creates a second video.
+     * This is the state the redelivered event observes after invariant #1 commits.
+     */
+    @Test
+    void alreadySyncedAssetUpdatesInsteadOfCreatingDuplicate() throws Exception {
+        ResourceResolver rr = context.resourceResolver();
+
+        // Simulate the marker a prior (committed) event would have written.
+        ModifiableValueMap meta = metadata(rr);
+        meta.put(Constants.BRC_ID, "999111");
+        meta.put(Constants.BRC_LASTSYNC, System.currentTimeMillis());
+        rr.commit();
+
+        Asset asset = rr.getResource(ASSET_PATH).adaptTo(Asset.class);
+        step.activateAsset(rr, asset, serviceUtil);
+
+        verify(serviceUtil, never()).createVideoS3(any(Video.class), anyString(), any(InputStream.class));
+        verify(serviceUtil, times(1)).updateVideo(any(Video.class));
+    }
+
+    private static ModifiableValueMap metadata(ResourceResolver rr) {
+        Resource metaRes = rr.getResource(ASSET_PATH).getChild(Constants.ASSET_METADATA_PATH);
+        return metaRes.adaptTo(ModifiableValueMap.class);
+    }
+
+    private static ObjectNode sentResponse(String videoId) {
+        ObjectNode node = JsonNodeFactory.instance.objectNode();
+        node.put(Constants.SENT, true);
+        node.put(Constants.VIDEOID, videoId);
+        return node;
+    }
+}


### PR DESCRIPTION
## BGS-1705: duplicate video creation on concurrent/redelivered publish

### Problem
On AEMaaCS, a publish can deliver the same distribution/replication event more than once, or two jobs can process the same asset near-simultaneously. The create-vs-update gate keys on the `brc_lastsync` marker, but that marker was only committed at the end of `execute()` — after a ~15s ingest wait. A second event running in its own JCR session still read `brc_lastsync == null` and created a second Brightcove video. Not reproducible on local instances, where publish jobs run sequentially.

### Fix
- **`ServiceUtil.createVideo`** — default `reference_id` to the asset's stable `jcr:uuid` when no explicit `brc_reference_id` is set. `reference_id` is unique per account, so the CMS API rejects a duplicate create (409 `REFERENCE_ID_IN_USE`) instead of silently producing a second video. The losing thread's response has no `id`, so `createVideoS3` returns `SENT=false` and creates nothing.
- **`BrightcoveSyncAssetWorkflowStep` / `BrightcovePublishListener`** — commit the sync marker immediately after a successful create, before the ingest wait, so a concurrent or redelivered event sees the asset as already-synced and takes the update path.

### Tests (first unit tests for the core module — JUnit5 + Mockito + aem-mock)
- `BrightcoveSyncAssetWorkflowStepDuplicateTest` — marker is committed before `activateAsset` returns; the gate routes on marker presence (create once, then update).
- `ServiceUtilReferenceIdTest` — `reference_id` derivation (explicit wins, else `jcr:uuid`).

### Verification
- Unit suite 6/6 green, with a discriminating control: removing the early commit makes `BrightcoveSyncAssetWorkflowStepDuplicateTest` fail (`marker must be committed before activateAsset returns`).
- Built 7.2.2 bundle deployed to a running AEM instance; all connector components activate with no errors.
- End-to-end on a running instance: publishing a new asset produces a video whose `reference_id` equals the asset's `jcr:uuid` (existing pre-fix videos have `reference_id = null`); re-publishing the same asset creates no duplicate.

### Notes / follow-ups (out of scope here)
- The losing concurrent thread logs a generic create-failed message rather than "already exists — adopting"; functionally harmless (no duplicate, winner's marker stands) but noisy in diagnostics.
- Pre-existing: `HttpServices.executePost` discards the error body on non-2xx (`getInputStream()` after `getErrorStream()`); does not affect duplicate-prevention.
