### PR TITLE
fix: inject Brightcove player loader once per page and guard null width/height

### DIFF
--- a/current/ui.apps/src/main/content/jcr_root/etc/designs/cs/brightcove/players/html5-player/js/BrightcoveExperiences.js
+++ b/current/ui.apps/src/main/content/jcr_root/etc/designs/cs/brightcove/players/html5-player/js/BrightcoveExperiences.js
@@ -37,6 +37,12 @@ r(function(){
     createPlayers();
 });
 function createPlayers() {
+    // Registry of injected player-loader <script> tags, keyed by loader src, so the
+    // index.min.js loader is added at most once per page even when multiple containers
+    // share a player or createPlayers() runs again on re-render. Previously the loader was
+    // appended once per container on every call, piling up dozens of duplicate <script>
+    // tags that re-ran the player factory repeatedly.
+    var loaders = createPlayers._loaders || (createPlayers._loaders = {});
     var all = document.getElementsByClassName("brightcove-container");
     for (var i = 0, max = all.length; i < max; i++) {
         var selected_element = all[i];
@@ -53,11 +59,14 @@ function createPlayers() {
         var dataWidth= selected_element.getAttribute("data-width");
         var dataHeight= selected_element.getAttribute("data-height");
         var dataUsage = selected_element.getAttribute("data-usage");
-        var s = document.createElement('script');
-        s.src = "//players.brightcove.net/" + dataAccount + "/" + dataPlayer + "_"+dataEmbed+"/index.min.js";
-        s.onload = (function(playerID,dataVideoId,dataAccount,dataPlayer,dataEmbed,dataWidth,dataHeight,selected_element) {
+        var src = "//players.brightcove.net/" + dataAccount + "/" + dataPlayer + "_" + dataEmbed + "/index.min.js";
+        var buildPlayer = (function(playerID,dataVideoId,dataAccount,dataPlayer,dataEmbed,dataWidth,dataHeight,selected_element) {
             return function() {
-                playerHTML = '<video id=\"' + playerID + '\" data-video-id=\"' + dataVideoId + '\"  data-account=\"' + dataAccount + '\" data-player=\"' + dataPlayer + '\" data-embed=\"' + dataEmbed + '\" data-usage=\"' + dataUsage + '\" class=\"video-js\" controls width=\"' + dataWidth + '\" height=\"' + dataHeight + '\"></video>';
+                // Only emit width/height when the author supplied them; a missing value was
+                // serialized as the string "null" (e.g. width="null"), triggering VIDEOJS
+                // "Improper value null supplied for width/height" errors on every init.
+                var sizeAttrs = (dataWidth ? ' width=\"' + dataWidth + '\"' : '') + (dataHeight ? ' height=\"' + dataHeight + '\"' : '');
+                playerHTML = '<video id=\"' + playerID + '\" data-video-id=\"' + dataVideoId + '\"  data-account=\"' + dataAccount + '\" data-player=\"' + dataPlayer + '\" data-embed=\"' + dataEmbed + '\" data-usage=\"' + dataUsage + '\" class=\"video-js\" controls' + sizeAttrs + '></video>';
                 selected_element.innerHTML = playerHTML;
                 bc(document.getElementById(playerID));
                 videojs(playerID).ready(function () {
@@ -108,6 +117,27 @@ function createPlayers() {
                 });
             };
         }(playerID,dataVideoId,dataAccount,dataPlayer,dataEmbed,dataWidth,dataHeight,selected_element));
-        document.body.appendChild(s);
+
+        var loader = loaders[src];
+        if (loader && loader.loaded) {
+            // Loader already present on the page: build this container immediately.
+            buildPlayer();
+        } else if (loader) {
+            // Loader request is in flight: queue this container until it finishes.
+            loader.queue.push(buildPlayer);
+        } else {
+            // First container needing this player: inject the loader <script> exactly once.
+            loader = loaders[src] = { loaded: false, queue: [buildPlayer] };
+            var s = document.createElement('script');
+            s.src = src;
+            s.onload = (function(ld) {
+                return function() {
+                    ld.loaded = true;
+                    for (var q = 0; q < ld.queue.length; q++) { ld.queue[q](); }
+                    ld.queue = [];
+                };
+            }(loader));
+            document.body.appendChild(s);
+        }
     }
 }


### PR DESCRIPTION
📋 **Case report:** https://etri-tech-support-cases-ajddb37viq-uc.a.run.app/cases/01588736

## Summary
- De-duplicates the client-side player loader: `createPlayers()` now injects each unique
  `players.brightcove.net/<acct>/<player>_<embed>/index.min.js` **once per page** instead of once
  per `.brightcove-container` per call.
- Stops serializing an unset player size as the string `"null"` (`width="null"` / `height="null"`).
- Raised by a customer report — **HDFC Bank**, SFDC case
  [01588736](https://brightcove2.lightning.force.com/lightning/r/Case/500Ph00001KuLCF/view) — where a
  carousel page loaded the same player library ~25×.

## Context
On a page with multiple player components — or one whose carousel clones player DOM nodes — the old
`createPlayers()` appended a fresh `index.min.js` `<script>` to `document.body` for **every**
`.brightcove-container`, with no dedup
([`BrightcoveExperiences.js@963c066`](https://github.com/brightcove/Adobe-AEM-Brightcove-Connector/blob/963c066/current/ui.apps/src/main/content/jcr_root/etc/designs/cs/brightcove/players/html5-player/js/BrightcoveExperiences.js#L39-L110)).
Each duplicate load re-ran the Video.js factory and produced repeated
`A plugin named "overlay" already exists` / `VIDEOJS: Ignoring already initialized player` console
noise plus avoidable main-thread cost. Separately, the `<video>` was always built with
`width="'+dataWidth+'"`; when the AEM author leaves size blank the attribute is absent and
`getAttribute` returns `null`, yielding a literal `width="null"` and
`VIDEOJS: ERROR: Improper value "null" supplied for width/height` on every init. HDFC's live pages
exhibit exactly this (`data-usage="cms:aem:6.5:6.0.6"`, no `data-width`/`data-height` on containers).

This PR tracks a `createPlayers._loaders` registry keyed by loader `src`: the first container needing
a given player injects the loader once and queues its build; further containers with the same `src`
build immediately (if loaded) or queue (if in flight). Width/height are emitted only when supplied.

## References
- 💬 **Slack thread:** `#brightcove-tech-support-cases` — (no permalink)
- 🎫 **Jira:** no dedicated ticket for this connector bug existed at time of writing (searched); file
  one and link it. Related context:
  [HSEO-113 — Hero video is not loading on Home page](https://brightcove.atlassian.net/browse/HSEO-113)
  (HDFC implementation project),
  [SEPROJ-1725 — John Hancock: Brightcove/AEM Connector Questions](https://brightcove.atlassian.net/browse/SEPROJ-1725)
  (AEM-connector precedent).
- 🔗 **Related code refs:**
  [`BrightcoveExperiences.js` (createPlayers, master)](https://github.com/brightcove/Adobe-AEM-Brightcove-Connector/blob/master/current/ui.apps/src/main/content/jcr_root/etc/designs/cs/brightcove/players/html5-player/js/BrightcoveExperiences.js#L39) ·
  [`player-embed.html` (container + `data-usage`)](https://github.com/brightcove/Adobe-AEM-Brightcove-Connector/blob/master/current/ui.apps/src/main/content/jcr_root/apps/brightcove/components/content/brightcoveplayer/player-embed.html#L31-L42) ·
  prior null-size fix [`792f3a2`](https://github.com/brightcove/Adobe-AEM-Brightcove-Connector/commit/792f3a2).

## Diff at a glance
| File | Change | LOC |
|---|---|---|
| `current/ui.apps/.../html5-player/js/BrightcoveExperiences.js` | dedup loader via `_loaders` registry + queue; emit width/height only when set | +35/-5 |

Total: 1 file, +35/-5.

## How it works
Single-file, client-side change — no cross-service data flow, so no diagram. In one line: keep a
per-page map of injected loader `<script>`s keyed by URL; inject once, queue each container's
`<video>` build until that one script loads, then drain the queue.

## Test plan
- [ ] Author an AEM page with **4+** Brightcove player components using the same player
      (`default_default`); publish.
- [ ] Load the page → DevTools **Network** filtered to `index.min.js` shows **1** request (was one
      per component); all videos initialise and play.
- [ ] **Console** shows no `A plugin named "overlay" already exists`, no
      `Ignoring already initialized player`, no `Improper value "null" supplied for width/height`.
- [ ] Author a component with **no** width/height → rendered `<video>` has no `width`/`height`
      attribute (not `width="null"`); responsive sizing from the player config still applies.
- [ ] Regression: a page with **two different** players (different `data-player`) loads **two**
      loaders, one each.
- [ ] CI green (link once available).

## Rollback
Single self-contained JS change with no persisted state or schema. Plain `git revert 55be86b` (or
redeploy the previous connector build/clientlib) is safe.

## Related conversation
Investigated by the Brightcove tech-support agent; full report on the BC Tech-Support console.
Slack thread: `#brightcove-tech-support-cases` (no permalink). Customer: HDFC Bank Limited (account
`6415735099001`), SFDC case
[01588736](https://brightcove2.lightning.force.com/lightning/r/Case/500Ph00001KuLCF/view).

🤖 Investigated + drafted with [Claude Code](https://claude.com/claude-code).