### PR TITLE
chore: bump version to 7.2.3

### DIFF
--- a/current/all/pom.xml
+++ b/current/all/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.2.2</version>
+        <version>7.2.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/analyse/pom.xml
+++ b/current/analyse/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.2.2</version>
+        <version>7.2.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/core/pom.xml
+++ b/current/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.2.2</version>
+        <version>7.2.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>brightcove.core</artifactId>

--- a/current/it.tests/pom.xml
+++ b/current/it.tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.2.2</version>
+        <version>7.2.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/pom.xml
+++ b/current/pom.xml
@@ -21,7 +21,7 @@
     <groupId>com.coresecure</groupId>
     <artifactId>brightcove</artifactId>
     <packaging>pom</packaging>
-    <version>7.2.2</version>
+    <version>7.2.3</version>
     <description>Brightcove Connector</description>
 
     <modules>

--- a/current/ui.apps.structure/pom.xml
+++ b/current/ui.apps.structure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.2.2</version>
+        <version>7.2.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.apps/pom.xml
+++ b/current/ui.apps/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.2.2</version>
+        <version>7.2.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.config/pom.xml
+++ b/current/ui.config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.2.2</version>
+        <version>7.2.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.content/pom.xml
+++ b/current/ui.content/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.2.2</version>
+        <version>7.2.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/current/ui.tests/pom.xml
+++ b/current/ui.tests/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.coresecure</groupId>
         <artifactId>brightcove</artifactId>
-        <version>7.2.2</version>
+        <version>7.2.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Bumps the cloud line from 7.2.2 to 7.2.3 across the root pom and all nine modules.

## Why now

`cloud-master` was still reading 7.2.2, which is an already-published tag (`7.2.2-cloud`, 2026-07-11) that does **not** contain the BGS-1705 duplicate-video fix merged in #128. Anyone building from `cloud-master` got a `brightcove.all-7.2.2.zip` whose contents differ from the released 7.2.2 artifact of the same name — indistinguishable by version, which is exactly the situation that makes a "nothing changed" QA report hard to diagnose.

This is the same bump-then-release pattern as #123 (7.2.1) and the 7.2.2 bump in `fe78c89`.

## Contents of the 7.2.3 line so far

- **BGS-1705** (#128) — duplicate-video prevention on the create path: `reference_id` defaults to the asset `jcr:uuid` so the CMS API rejects a duplicate create with `409 REFERENCE_ID_IN_USE`, and both create paths commit the sync marker whole and immediately after a successful create rather than behind the ~15s ingest wait. Also switches the workflow step's folder-sync recovery from a session-wide `refresh(false)` to `refresh(true)`.

The same fix shipped to the 7.1.4 hotfix line as [7.1.4.3-cloud](https://github.com/brightcove/Adobe-AEM-Brightcove-Connector/releases/tag/7.1.4.3-cloud) via #130, for customers who are not on 7.2.x.

## Verification

`mvn clean install` succeeds; unit suite green (7/7 in `core`); `brightcove.all-7.2.3.zip` builds. Version-only change, no source touched.